### PR TITLE
Add compatibility for apache 2.4 out of the box

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -306,14 +306,14 @@ AddDefaultCharset utf-8
 # danger when anyone has access to them.
 
 <FilesMatch "(^#.*#|\.(bak|config|dist|fla|inc|ini|log|psd|sh|sql|sw[op])|~)$">
-    <IfVersion < 2.3>
+    <IfModule !mod_authz_core.c>
         Order allow,deny
         Deny from all
         Satisfy All 
-    </IfVersion>
-    <IfVersion >= 2.3>
+    </IfModule>
+    <IfModule mod_authz_core.c>
         Require all denied
-    </IfVersion>
+    </IfModule>
 </FilesMatch>
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Using .htaccess as is on Apache 2.4 make it halt with error 500 because `Order` directive is deprecated in favour of `Require`.
This patch checks existence of `mod_authz_host` module, available in Apache 2.3 and later and uses the right directive supported by Apache
