### PR TITLE
Add Apache 2.4 compatibility

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -306,9 +306,17 @@ AddDefaultCharset utf-8
 # danger when anyone has access to them.
 
 <FilesMatch "(^#.*#|\.(bak|config|dist|fla|inc|ini|log|psd|sh|sql|sw[op])|~)$">
-    Order allow,deny
-    Deny from all
-    Satisfy All
+    # Apache < 2.3
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+        Satisfy All
+    </IfModule>
+
+    # Apache ≥ 2.3
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
 </FilesMatch>
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
As of Apache 2.3 the `Order`, `Allow`, `Deny` directives are replaced by the `Require` directive, making Apache 2.2 configuration not compatible with Apache 2.4.
This patch checks for [`mod_authz_core`](http://httpd.apache.org/docs/2.4/mod/mod_authz_core.html) base module presence (available from 2.3 release) to enable the correct syntax.

Closes issue #5.
