### PR TITLE
Correct mime-types for atom, rdf, and rss

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ moment to review the [guidelines](CONTRIBUTING.md).
 only possible thanks to all the awesome
 [contributors](https://github.com/h5bp/server-configs-apache/graphs/contributors)!
 
-This project is currently maintained by:
-
-| [![@alrra](https://avatars.githubusercontent.com/u/1223565?s=120)](https://github.com/alrra "Follow @alrra on GitHub") |
-|:---:|:---:|
-| [Cătălin Mariș](https://github.com/alrra) |
-
 
 ## License
 

--- a/src/media_types/media_types.conf
+++ b/src/media_types/media_types.conf
@@ -11,10 +11,13 @@
 
   # Data interchange
 
+    AddType application/atom+xml                        atom
     AddType application/json                            json map topojson
     AddType application/ld+json                         jsonld
+    AddType application/rdf+xml                         rdf
+    AddType application/rss+xml                         rss
     AddType application/vnd.geo+json                    geojson
-    AddType application/xml                             atom rdf rss xml
+    AddType application/xml                             xml
 
 
   # JavaScript


### PR DESCRIPTION
This solves some issues with nosniff header also.

atom: application/atom+xml  (https://www.iana.org/assignments/media-types/media-types.xhtml)
rdf:    application/rdf+xml (http://www.w3.org/2008/01/rdf-media-types)
rss:   application/rss+xml (http://www.rssboard.org/rss-mime-type-application.txt)