### PR TITLE
Use IncludesNOEXEC instead of just Includes option

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -903,14 +903,14 @@ FileETag None
 
 # <IfModule mod_include.c>
 #     <FilesMatch "\.combined\.js$">
-#         Options +Includes
+#         Options +IncludesNOEXEC
 #         AddOutputFilterByType INCLUDES application/javascript \
 #                                        application/x-javascript \
 #                                        text/javascript
 #         SetOutputFilter INCLUDES
 #     </FilesMatch>
 #     <FilesMatch "\.combined\.css$">
-#         Options +Includes
+#         Options +IncludesNOEXEC
 #         AddOutputFilterByType INCLUDES text/css
 #         SetOutputFilter INCLUDES
 #     </FilesMatch>

--- a/src/web_performance/file_concatenation.conf
+++ b/src/web_performance/file_concatenation.conf
@@ -17,14 +17,14 @@
 
 <IfModule mod_include.c>
     <FilesMatch "\.combined\.js$">
-        Options +Includes
+        Options +IncludesNOEXEC
         AddOutputFilterByType INCLUDES application/javascript \
                                        application/x-javascript \
                                        text/javascript
         SetOutputFilter INCLUDES
     </FilesMatch>
     <FilesMatch "\.combined\.css$">
-        Options +Includes
+        Options +IncludesNOEXEC
         AddOutputFilterByType INCLUDES text/css
         SetOutputFilter INCLUDES
     </FilesMatch>


### PR DESCRIPTION
For security purposes it would be best to use IncludesNOEXEC option instead of just Includes.

See here:
http://httpd.apache.org/docs/current/misc/security_tips.html#ssi