### PR TITLE
gitattributes: override *.conf using linguist-language=ApacheConf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Automatically normalize line endings for all text-based files
 # http://git-scm.com/docs/gitattributes#_end_of_line_conversion
 * text=auto
+
+# Recognize .conf files as ApacheConf in GitHub
+# https://github.com/github/linguist/blob/master/README.md
+*.conf linguist-language=ApacheConf
+


### PR DESCRIPTION
Helps to recognize .conf files as ApacheConf files in GitHub as
described at https://github.com/github/linguist/blob/master/README.md

Currently this repo has 43% JavaScript and 40% Apache files.