### PR TITLE
Block Mercurial .orig files

### DIFF
--- a/src/security/file_access.conf
+++ b/src/security/file_access.conf
@@ -53,7 +53,7 @@
 # include: configuration files, files that contain metadata about the
 # project (e.g.: project dependencies), build scripts, etc..
 
-<FilesMatch "(^#.*#|\.(bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$">
+<FilesMatch "(^#.*#|\.(bak|conf|dist|fla|in[ci]|log|orig|psd|sh|sql|sw[op])|~)$">
 
     # Apache < 2.3
     <IfModule !mod_authz_core.c>


### PR DESCRIPTION
Mercurial creates a backup file with the extension .orig when a file is reverted. This could lead to a potential leak of sensitive information.
