### PR TITLE
only set X-UA-Compatible header if html document

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -124,14 +124,12 @@ Options -MultiViews
 
 <IfModule mod_headers.c>
 
-    Header set X-UA-Compatible "IE=edge"
-
     # `mod_headers` cannot match based on the content-type, however,
     # the `X-UA-Compatible` response header should be sent only for
     # HTML documents and not for the other resources.
 
-    <FilesMatch "\.(appcache|atom|bbaw|bmp|crx|css|cur|eot|f4[abpv]|flv|geojson|gif|htc|ico|jpe?g|js|json(ld)?|m4[av]|manifest|map|mp4|oex|og[agv]|opus|otf|pdf|png|rdf|rss|safariextz|svgz?|swf|topojson|tt[cf]|txt|vcard|vcf|vtt|webapp|web[mp]|webmanifest|woff2?|xloc|xml|xpi)$">
-        Header unset X-UA-Compatible
+    <FilesMatch "\.(html)$">
+        Header set X-UA-Compatible "IE=edge"
     </FilesMatch>
 
 </IfModule>


### PR DESCRIPTION
modified lines 132-133 to only set the X-UA-Compatible header if it is
a html file as per the comments instead of setting it and un-setting it
for non-HTML files