### PR TITLE
Do not check HTTPS status when forcing/supressing www.

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -379,7 +379,6 @@ AddDefaultCharset utf-8
 
 <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteCond %{HTTPS} !=on
     RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
     RewriteRule ^ %{ENV:PROTO}://%1%{REQUEST_URI} [R=301,L]
 </IfModule>
@@ -393,7 +392,6 @@ AddDefaultCharset utf-8
 
 # <IfModule mod_rewrite.c>
 #     RewriteEngine On
-#     RewriteCond %{HTTPS} !=on
 #     RewriteCond %{HTTP_HOST} !^www\. [NC]
 #     RewriteCond %{SERVER_ADDR} !=127.0.0.1
 #     RewriteCond %{SERVER_ADDR} !=::1


### PR DESCRIPTION
This PR fixes a bug in the .htaccess file where apache2 will stop forcing/suppressing www when HTTPS is first forced on. (Running Ubuntu 16.04)

To reproduce:
-  In section "Forcing 'https://'" uncomment the following to force HTTPS.
```
# <IfModule mod_rewrite.c>
#    RewriteEngine On
#    RewriteCond %{HTTPS} !=on
#    RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R=301,L]
# </IfModule>
```

-  In section "Suppressing / Forcing the `www.` at the beginning of URLs" uncomment either Option 1 or Option 2.

-  https will be forced on as desired but under Option 1 and Option 2, the RewriteCond %{HTTPS} !=on is stopping https://www to https:// or https:// to https://www rewrite execution.  More at https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritecond