### PR TITLE
Prevent forcing https on local hosts

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -352,6 +352,8 @@ AddDefaultCharset utf-8
 # <IfModule mod_rewrite.c>
 #    RewriteEngine On
 #    RewriteCond %{HTTPS} !=on
+#    RewriteCond %{SERVER_ADDR} !=127.0.0.1
+#    RewriteCond %{SERVER_ADDR} !=::1
 #    RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R=301,L]
 # </IfModule>
 

--- a/src/rewrites/rewrite_http_to_https.conf
+++ b/src/rewrites/rewrite_http_to_https.conf
@@ -8,5 +8,7 @@
 <IfModule mod_rewrite.c>
    RewriteEngine On
    RewriteCond %{HTTPS} !=on
+   RewriteCond %{SERVER_ADDR} !=127.0.0.1
+   RewriteCond %{SERVER_ADDR} !=::1
    RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R=301,L]
 </IfModule>


### PR DESCRIPTION
Hey.
I don't know what you guys think but, I think it'll never be necessary to have local hosts forcing https, so I've included the same lines contained on `src/rewrites/rewrite_www.conf` to the `src/rewrites/rewrite_http_to_https.conf` file.
I couldn't run the tests here, mainly probably because of the outdated devDependencies, so I've edited manually on the dist file as well.
If you do not agree by any reason, I'd like to explain me why, if possible.
Thank you guys. =)