### PR TITLE
Change the rule of forcing https to keep up the request uri

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -352,7 +352,7 @@ AddDefaultCharset utf-8
 # <IfModule mod_rewrite.c>
 #    RewriteEngine On
 #    RewriteCond %{HTTPS} !=on
-#    RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R=301,L]
+#    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 # </IfModule>
 
 # ----------------------------------------------------------------------

--- a/src/rewrites/rewrite_http_to_https.conf
+++ b/src/rewrites/rewrite_http_to_https.conf
@@ -8,5 +8,5 @@
 <IfModule mod_rewrite.c>
    RewriteEngine On
    RewriteCond %{HTTPS} !=on
-   RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R=301,L]
+   RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </IfModule>


### PR DESCRIPTION
Hi again.
I had a case where something like `http://www.domain.com/subdirectory/` was redirecting to `https://www.domain.com`, by the actual project code for https force, located on `src/rewrites/rewrite_http_to_https.conf`:

```apache
RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R=301,L]
```

While testing, I made this update which has fixed the issue:

```apache
RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
```

=) anything, let me know. Cheers.

Note: I couldn't run the tests here (devDependencies outdated).