### PR TITLE
Font MIME types following RFC 8081

### DIFF
--- a/src/media_types/media_types.conf
+++ b/src/media_types/media_types.conf
@@ -55,20 +55,11 @@
 
   # Web fonts
 
-    AddType application/font-woff                       woff
-    AddType application/font-woff2                      woff2
+    AddType font/woff                                   woff
+    AddType font/woff2                                  woff2
     AddType application/vnd.ms-fontobject               eot
-
-    # Browsers usually ignore the font media types and simply sniff
-    # the bytes to figure out the font type.
-    # https://mimesniff.spec.whatwg.org/#matching-a-font-type-pattern
-    #
-    # However, Blink and WebKit based browsers will show a warning
-    # in the console if the following font types are served with any
-    # other media types.
-
-    AddType application/x-font-ttf                      ttc ttf
-    AddType font/opentype                               otf
+    AddType font/ttf                                    ttc ttf
+    AddType font/otf                                    otf
 
 
   # Other

--- a/src/media_types/media_types.conf
+++ b/src/media_types/media_types.conf
@@ -58,7 +58,8 @@
     AddType font/woff                                   woff
     AddType font/woff2                                  woff2
     AddType application/vnd.ms-fontobject               eot
-    AddType font/ttf                                    ttc ttf
+    AddType font/ttf                                    ttf
+    AddType font/collection                             ttc
     AddType font/otf                                    otf
 
 

--- a/src/web_performance/compression.conf
+++ b/src/web_performance/compression.conf
@@ -41,8 +41,11 @@
                                       "application/x-web-app-manifest+json" \
                                       "application/xhtml+xml" \
                                       "application/xml" \
+                                      "font/collection" \
                                       "font/eot" \
+                                      "font/opentype" \
                                       "font/otf" \
+                                      "font/ttf" \
                                       "image/bmp" \
                                       "image/svg+xml" \
                                       "image/vnd.microsoft.icon" \

--- a/src/web_performance/compression.conf
+++ b/src/web_performance/compression.conf
@@ -42,7 +42,7 @@
                                       "application/xhtml+xml" \
                                       "application/xml" \
                                       "font/eot" \
-                                      "font/opentype" \
+                                      "font/otf" \
                                       "image/bmp" \
                                       "image/svg+xml" \
                                       "image/vnd.microsoft.icon" \

--- a/src/web_performance/expires_headers.conf
+++ b/src/web_performance/expires_headers.conf
@@ -85,9 +85,11 @@
 
     # OpenType
     ExpiresByType font/opentype                         "access plus 1 month"
+    ExpiresByType font/otf                              "access plus 1 month"
 
     # TrueType
     ExpiresByType application/x-font-ttf                "access plus 1 month"
+    ExpiresByType font/ttf                              "access plus 1 month"
 
     # Web Open Font Format (WOFF) 1.0
     ExpiresByType application/font-woff                 "access plus 1 month"
@@ -96,6 +98,7 @@
 
     # Web Open Font Format (WOFF) 2.0
     ExpiresByType application/font-woff2                "access plus 1 month"
+    ExpiresByType font/woff-2                           "access plus 1 month"
 
 
   # Other

--- a/src/web_performance/expires_headers.conf
+++ b/src/web_performance/expires_headers.conf
@@ -79,6 +79,9 @@
 
   # Web fonts
 
+    # Collection
+    ExpiresByType font/collection                       "access plus 1 month"
+
     # Embedded OpenType (EOT)
     ExpiresByType application/vnd.ms-fontobject         "access plus 1 month"
     ExpiresByType font/eot                              "access plus 1 month"

--- a/src/web_performance/expires_headers.conf
+++ b/src/web_performance/expires_headers.conf
@@ -101,7 +101,7 @@
 
     # Web Open Font Format (WOFF) 2.0
     ExpiresByType application/font-woff2                "access plus 1 month"
-    ExpiresByType font/woff-2                           "access plus 1 month"
+    ExpiresByType font/woff2                            "access plus 1 month"
 
 
   # Other

--- a/test/tests.js
+++ b/test/tests.js
@@ -355,7 +355,7 @@ exports = module.exports = {
                 'test.otf': {
                     responseHeaders: {
                         'access-control-allow-origin': '*',
-                        'content-type': 'font/opentype'
+                        'content-type': 'font/otf'
                     }
                 },
 
@@ -436,14 +436,14 @@ exports = module.exports = {
                 'test.ttc': {
                     responseHeaders: {
                         'access-control-allow-origin': '*',
-                        'content-type': 'application/x-font-ttf'
+                        'content-type': 'font/collection'
                     }
                 },
 
                 'test.ttf': {
                     responseHeaders: {
                         'access-control-allow-origin': '*',
-                        'content-type': 'application/x-font-ttf'
+                        'content-type': 'font/ttf'
                     }
                 },
 
@@ -508,7 +508,7 @@ exports = module.exports = {
                     responseHeaders: {
                         'access-control-allow-origin': '*',
                         'content-encoding': null,
-                        'content-type': 'application/font-woff'
+                        'content-type': 'font/woff'
                     }
                 },
 
@@ -516,7 +516,7 @@ exports = module.exports = {
                     responseHeaders: {
                         'access-control-allow-origin': '*',
                         'content-encoding': null,
-                        'content-type': 'application/font-woff2'
+                        'content-type': 'font/woff2'
                     }
                 },
 


### PR DESCRIPTION
Recent changes introduced by the [RFC 8081](https://tools.ietf.org/html/rfc8081) and [registered at IANA](https://www.iana.org/assignments/media-types/media-types.xml#font).

Current|New
---|---
`application/x-font-ttf`|`font/ttf`
`font/opentype`|`font/otf`
`application/font-woff`|`font/woff`
`application/font-woff2`|`font/woff2`
`application/x-font-ttf` (ttc)|`font/collection`