### PR TITLE
Use precise dist for Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ git:
 
 language: node_js
 
+dist: precise
+
 matrix:
   include:
 


### PR DESCRIPTION
Fixes error on Travis.
See https://blog.travis-ci.com/2017-08-31-trusty-as-default-status

Should be relevant to update to trusty dist in the near future, but require some script changes.