### PR TITLE
media type application/javascript => text/javascript

### DIFF
--- a/src/media_types/media_types.conf
+++ b/src/media_types/media_types.conf
@@ -21,10 +21,10 @@
 
   # JavaScript
 
-    # Normalize to standard type.
-    # https://tools.ietf.org/html/rfc4329#section-7.2
+    # Servers should use text/javascript for JavaScript resources.
+    # https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages
 
-    AddType application/javascript                      js mjs
+    AddType text/javascript                             js mjs
 
 
   # Manifest files

--- a/test/tests.js
+++ b/test/tests.js
@@ -257,7 +257,7 @@ exports = module.exports = {
                 'test.js': {
                     responseHeaders: {
                         'cache-control': 'max-age=31536000, no-transform',
-                        'content-type': 'application/javascript; charset=utf-8'
+                        'content-type': 'text/javascript; charset=utf-8'
                     }
                 },
 


### PR DESCRIPTION
> Similarly, the MIME type used to refer to JavaScript in this specification is `text/javascript`, since that is the most commonly used type, despite it being an officially obsoleted type according to RFC 4329.

> Servers should use `text/javascript` for JavaScript resources. Servers should not use other JavaScript MIME types for JavaScript resources, and must not use non-JavaScript MIME types.

Ref:
* https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages
* bmeck/I-D#2
* https://tools.ietf.org/html/draft-ietf-dispatch-javascript-mjs-00