### PR TITLE
Add serving pre-compressed content section

### DIFF
--- a/htaccess.conf
+++ b/htaccess.conf
@@ -85,6 +85,8 @@ enable  "src/security/server_software_information.conf"
 
 title   "web performance"
 enable  "src/web_performance/compression.conf"
+disable "src/web_performance/pre-compressed_content_brotli.conf"
+disable "src/web_performance/pre-compressed_content_gzip.conf"
 disable "src/web_performance/content_transformation.conf"
 enable  "src/web_performance/etags.conf"
 enable  "src/web_performance/expires_headers.conf"

--- a/src/files_match_pattern
+++ b/src/files_match_pattern
@@ -7,6 +7,7 @@ appcache
 atom
 bbaw
 bmp
+br
 crx
 css
 cur
@@ -15,6 +16,7 @@ f4[abpv]
 flv
 geojson
 gif
+gz
 htc
 ic[os]
 jpe?g

--- a/src/web_performance/pre-compressed_content_brotli.conf
+++ b/src/web_performance/pre-compressed_content_brotli.conf
@@ -8,20 +8,31 @@
     # and the client accepts br.
     RewriteCond %{HTTP:Accept-Encoding} br
     RewriteCond %{REQUEST_FILENAME}\.br -f
-    RewriteRule \.(css|js|html|svg|ics|json)$ %{REQUEST_URI}.br [L]
+    RewriteRule \.(css|ics|js|json|html|svg)$ %{REQUEST_URI}.br [L]
 
-    # Serve correct content types, and prevent mod_deflate double gzip.
-    RewriteRule "\.css\.br$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.br$" "-" [T=text/javascript;charset=UTF-8,E=no-gzip:1]
-    RewriteRule "\.html\.br$" "-" [T=text/html,E=no-gzip:1]
-    RewriteRule "\.svg\.br$" "-" [T=image/svg+xml,E=no-gzip:1]
-    RewriteRule "\.ics\.br$" "-" [T=text/calendar,E=no-gzip:1]
-    RewriteRule "\.json\.br$" "-" [T=text/json,E=no-gzip:1]
+    # Prevent mod_deflate double gzip.
+    RewriteRule \.br$ - [E=no-gzip:1]
 
     <FilesMatch "\.br$">
-      # Force proxies to cache gzipped &
-      # non-brotlied css/js files separately.
-      Header append Vary Accept-Encoding
+
+        # Serve correct content types.
+        <IfModule mod_mime.c>
+            AddType text/css              css.br
+            AddType text/calendar         ics.br
+            AddType text/javascript       js.br
+            AddType application/json      json.br
+            AddType text/html             html.br
+            AddType image/svg+xml         svg.br
+
+            AddCharset utf-8 .css.br \
+                             .ics.br \
+                             .js.br \
+                             .json.br
+        </IfModule>
+
+        # Force proxies to cache brotlied and non-brotlied files separately.
+        Header append Vary Accept-Encoding
+
     </FilesMatch>
 
     # Serve correct encoding type.

--- a/src/web_performance/pre-compressed_content_brotli.conf
+++ b/src/web_performance/pre-compressed_content_brotli.conf
@@ -12,7 +12,7 @@
 
     # Serve correct content types, and prevent mod_deflate double gzip.
     RewriteRule "\.css\.br$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.br$" "-" [T=text/javascript,E=no-gzip:1]
+    RewriteRule "\.js\.br$" "-" [T=text/javascript; charset=utf-8,E=no-gzip:1]
     RewriteRule "\.html\.br$" "-" [T=text/html,E=no-gzip:1]
     RewriteRule "\.svg\.br$" "-" [T=image/svg+xml,E=no-gzip:1]
     RewriteRule "\.ics\.br$" "-" [T=text/calendar,E=no-gzip:1]

--- a/src/web_performance/pre-compressed_content_brotli.conf
+++ b/src/web_performance/pre-compressed_content_brotli.conf
@@ -12,7 +12,7 @@
 
     # Serve correct content types, and prevent mod_deflate double gzip.
     RewriteRule "\.css\.br$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.br$" "-" [T=text/javascript; charset=utf-8,E=no-gzip:1]
+    RewriteRule "\.js\.br$" "-" [T=text/javascript; charset=UTF-8,E=no-gzip:1]
     RewriteRule "\.html\.br$" "-" [T=text/html,E=no-gzip:1]
     RewriteRule "\.svg\.br$" "-" [T=image/svg+xml,E=no-gzip:1]
     RewriteRule "\.ics\.br$" "-" [T=text/calendar,E=no-gzip:1]

--- a/src/web_performance/pre-compressed_content_brotli.conf
+++ b/src/web_performance/pre-compressed_content_brotli.conf
@@ -1,22 +1,29 @@
 # ----------------------------------------------------------------------
-# | Serving Brotli pre-compressed content                              |
+# | Brotli pre-compressed content                                      |
 # ----------------------------------------------------------------------
+
+# Serve brotli compressed CSS, JS, HTML, SVG, ICS and JSON files
+# if they exist and if the client accepts br encoding.
+#
+# (!) To make this part relevant, you need to generate encoded
+# files by your own. Enabling this part will not auto-generate
+# brotlied files.
+#
+# https://httpd.apache.org/docs/current/mod/mod_brotli.html#precompressed
 
 <IfModule mod_headers.c>
 
-    # Serve brotli compressed CSS, JS, HTML, SVG, ICS and JSON files if they exist
-    # and the client accepts br.
     RewriteCond %{HTTP:Accept-Encoding} br
     RewriteCond %{REQUEST_FILENAME}\.br -f
     RewriteRule \.(css|ics|js|json|html|svg)$ %{REQUEST_URI}.br [L]
 
-    # Prevent mod_deflate double gzip.
+    # Prevent mod_deflate double gzip
     RewriteRule \.br$ - [E=no-gzip:1]
 
     <FilesMatch "\.br$">
 
-        # Serve correct content types.
         <IfModule mod_mime.c>
+            # Serve correct content types
             AddType text/css              css.br
             AddType text/calendar         ics.br
             AddType text/javascript       js.br
@@ -24,18 +31,19 @@
             AddType text/html             html.br
             AddType image/svg+xml         svg.br
 
+            # Serve correct content charset
             AddCharset utf-8 .css.br \
                              .ics.br \
                              .js.br \
                              .json.br
         </IfModule>
 
-        # Force proxies to cache brotlied and non-brotlied files separately.
+        # Force proxies to cache brotlied and non-brotlied files separately
         Header append Vary Accept-Encoding
 
     </FilesMatch>
 
-    # Serve correct encoding type.
+    # Serve correct encoding type
     AddEncoding br .br
 
 </IfModule>

--- a/src/web_performance/pre-compressed_content_brotli.conf
+++ b/src/web_performance/pre-compressed_content_brotli.conf
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------
-# | Serving pre-compressed content                                     |
+# | Serving Brotli pre-compressed content                              |
 # ----------------------------------------------------------------------
 
 <IfModule mod_headers.c>
@@ -26,32 +26,5 @@
 
     # Serve correct encoding type.
     AddEncoding br .br
-
-</IfModule>
-
-<IfModule mod_headers.c>
-
-    # Serve gzip compressed CSS, JS, HTML, SVG, ICS and JSON files if they exist
-    # and the client accepts gzip.
-    RewriteCond %{HTTP:Accept-Encoding} gzip
-    RewriteCond %{REQUEST_FILENAME}\.gz -f
-    RewriteRule \.(css|js|html|svg|ics|json)$ %{REQUEST_URI}.gz [L]
-
-    # Serve correct content types, and prevent mod_deflate double gzip.
-    RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1]
-    RewriteRule "\.html\.gz$" "-" [T=text/html,E=no-gzip:1]
-    RewriteRule "\.svg\.gz$" "-" [T=image/svg+xml,E=no-gzip:1]
-    RewriteRule "\.ics\.gz$" "-" [T=text/calendar,E=no-gzip:1]
-    RewriteRule "\.json\.gz$" "-" [T=text/json,E=no-gzip:1]
-
-    <FilesMatch "\.gz$">
-      # Force proxies to cache gzipped &
-      # non-gzipped css/js files separately.
-      Header append Vary Accept-Encoding
-    </FilesMatch>
-
-    # Serve correct encoding type.
-    AddEncoding gzip .gz
 
 </IfModule>

--- a/src/web_performance/pre-compressed_content_brotli.conf
+++ b/src/web_performance/pre-compressed_content_brotli.conf
@@ -12,7 +12,7 @@
 
     # Serve correct content types, and prevent mod_deflate double gzip.
     RewriteRule "\.css\.br$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.br$" "-" [T=text/javascript; charset=UTF-8,E=no-gzip:1]
+    RewriteRule "\.js\.br$" "-" [T=text/javascript;charset=UTF-8,E=no-gzip:1]
     RewriteRule "\.html\.br$" "-" [T=text/html,E=no-gzip:1]
     RewriteRule "\.svg\.br$" "-" [T=image/svg+xml,E=no-gzip:1]
     RewriteRule "\.ics\.br$" "-" [T=text/calendar,E=no-gzip:1]

--- a/src/web_performance/pre-compressed_content_gzip.conf
+++ b/src/web_performance/pre-compressed_content_gzip.conf
@@ -1,0 +1,30 @@
+# ----------------------------------------------------------------------
+# | Serving GZip pre-compressed content                                |
+# ----------------------------------------------------------------------
+
+<IfModule mod_headers.c>
+
+    # Serve gzip compressed CSS, JS, HTML, SVG, ICS and JSON files if they exist
+    # and the client accepts gzip.
+    RewriteCond %{HTTP:Accept-Encoding} gzip
+    RewriteCond %{REQUEST_FILENAME}\.gz -f
+    RewriteRule \.(css|js|html|svg|ics|json)$ %{REQUEST_URI}.gz [L]
+
+    # Serve correct content types, and prevent mod_deflate double gzip.
+    RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
+    RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1]
+    RewriteRule "\.html\.gz$" "-" [T=text/html,E=no-gzip:1]
+    RewriteRule "\.svg\.gz$" "-" [T=image/svg+xml,E=no-gzip:1]
+    RewriteRule "\.ics\.gz$" "-" [T=text/calendar,E=no-gzip:1]
+    RewriteRule "\.json\.gz$" "-" [T=text/json,E=no-gzip:1]
+
+    <FilesMatch "\.gz$">
+      # Force proxies to cache gzipped &
+      # non-gzipped css/js files separately.
+      Header append Vary Accept-Encoding
+    </FilesMatch>
+
+    # Serve correct encoding type.
+    AddEncoding gzip .gz
+
+</IfModule>

--- a/src/web_performance/pre-compressed_content_gzip.conf
+++ b/src/web_performance/pre-compressed_content_gzip.conf
@@ -12,7 +12,7 @@
 
     # Serve correct content types, and prevent mod_deflate double gzip.
     RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1]
+    RewriteRule "\.js\.gz$" "-" [T=text/javascript; charset=utf-8,E=no-gzip:1]
     RewriteRule "\.html\.gz$" "-" [T=text/html,E=no-gzip:1]
     RewriteRule "\.svg\.gz$" "-" [T=image/svg+xml,E=no-gzip:1]
     RewriteRule "\.ics\.gz$" "-" [T=text/calendar,E=no-gzip:1]

--- a/src/web_performance/pre-compressed_content_gzip.conf
+++ b/src/web_performance/pre-compressed_content_gzip.conf
@@ -8,20 +8,31 @@
     # and the client accepts gzip.
     RewriteCond %{HTTP:Accept-Encoding} gzip
     RewriteCond %{REQUEST_FILENAME}\.gz -f
-    RewriteRule \.(css|js|html|svg|ics|json)$ %{REQUEST_URI}.gz [L]
+    RewriteRule \.(css|ics|js|json|html|svg)$ %{REQUEST_URI}.gz [L]
 
-    # Serve correct content types, and prevent mod_deflate double gzip.
-    RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.gz$" "-" [T=text/javascript;charset=UTF-8,E=no-gzip:1]
-    RewriteRule "\.html\.gz$" "-" [T=text/html,E=no-gzip:1]
-    RewriteRule "\.svg\.gz$" "-" [T=image/svg+xml,E=no-gzip:1]
-    RewriteRule "\.ics\.gz$" "-" [T=text/calendar,E=no-gzip:1]
-    RewriteRule "\.json\.gz$" "-" [T=text/json,E=no-gzip:1]
+    # Prevent mod_deflate double gzip.
+    RewriteRule \.gz$ - [E=no-gzip:1]
 
     <FilesMatch "\.gz$">
-      # Force proxies to cache gzipped &
-      # non-gzipped css/js files separately.
-      Header append Vary Accept-Encoding
+
+        # Serve correct content types.
+        <IfModule mod_mime.c>
+            AddType text/css              css.gz
+            AddType text/calendar         ics.gz
+            AddType text/javascript       js.gz
+            AddType application/json      json.gz
+            AddType text/html             html.gz
+            AddType image/svg+xml         svg.gz
+
+            AddCharset utf-8 .css.gz \
+                             .ics.gz \
+                             .js.gz \
+                             .json.gz
+        </IfModule>
+
+        # Force proxies to cache gzipped and non-gzipped files separately.
+        Header append Vary Accept-Encoding
+
     </FilesMatch>
 
     # Serve correct encoding type.

--- a/src/web_performance/pre-compressed_content_gzip.conf
+++ b/src/web_performance/pre-compressed_content_gzip.conf
@@ -12,7 +12,7 @@
 
     # Serve correct content types, and prevent mod_deflate double gzip.
     RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.gz$" "-" [T=text/javascript; charset=UTF-8,E=no-gzip:1]
+    RewriteRule "\.js\.gz$" "-" [T=text/javascript;charset=UTF-8,E=no-gzip:1]
     RewriteRule "\.html\.gz$" "-" [T=text/html,E=no-gzip:1]
     RewriteRule "\.svg\.gz$" "-" [T=image/svg+xml,E=no-gzip:1]
     RewriteRule "\.ics\.gz$" "-" [T=text/calendar,E=no-gzip:1]

--- a/src/web_performance/pre-compressed_content_gzip.conf
+++ b/src/web_performance/pre-compressed_content_gzip.conf
@@ -12,7 +12,7 @@
 
     # Serve correct content types, and prevent mod_deflate double gzip.
     RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.gz$" "-" [T=text/javascript; charset=utf-8,E=no-gzip:1]
+    RewriteRule "\.js\.gz$" "-" [T=text/javascript; charset=UTF-8,E=no-gzip:1]
     RewriteRule "\.html\.gz$" "-" [T=text/html,E=no-gzip:1]
     RewriteRule "\.svg\.gz$" "-" [T=image/svg+xml,E=no-gzip:1]
     RewriteRule "\.ics\.gz$" "-" [T=text/calendar,E=no-gzip:1]

--- a/src/web_performance/pre-compressed_content_gzip.conf
+++ b/src/web_performance/pre-compressed_content_gzip.conf
@@ -1,22 +1,40 @@
 # ----------------------------------------------------------------------
-# | Serving GZip pre-compressed content                                |
+# | GZip pre-compressed content                                        |
 # ----------------------------------------------------------------------
+
+# Serve gzip compressed CSS, JS, HTML, SVG, ICS and JSON files
+# if they exist and if the client accepts gzip encoding.
+#
+# (!) To make this part relevant, you need to generate encoded
+# files by your own. Enabling this part will not auto-generate
+# gziped files.
+#
+# https://httpd.apache.org/docs/current/mod/mod_deflate.html#precompressed
+#
+# (1)
+# Removing default MIME Type for .gz files allowing to add custom
+# sub-types.
+# You may prefer using less generic extensions such as .html_gz in
+# order to keep default behavior regarding .gz files.
+# https://httpd.apache.org/docs/current/mod/mod_mime.html#removetype
 
 <IfModule mod_headers.c>
 
-    # Serve gzip compressed CSS, JS, HTML, SVG, ICS and JSON files if they exist
-    # and the client accepts gzip.
     RewriteCond %{HTTP:Accept-Encoding} gzip
     RewriteCond %{REQUEST_FILENAME}\.gz -f
     RewriteRule \.(css|ics|js|json|html|svg)$ %{REQUEST_URI}.gz [L]
 
-    # Prevent mod_deflate double gzip.
+    # Prevent mod_deflate double gzip
     RewriteRule \.gz$ - [E=no-gzip:1]
 
     <FilesMatch "\.gz$">
 
-        # Serve correct content types.
+        # Serve correct content types
         <IfModule mod_mime.c>
+            # (1)
+            RemoveType gz
+
+            # Serve correct content types
             AddType text/css              css.gz
             AddType text/calendar         ics.gz
             AddType text/javascript       js.gz
@@ -24,18 +42,19 @@
             AddType text/html             html.gz
             AddType image/svg+xml         svg.gz
 
+            # Serve correct content charset
             AddCharset utf-8 .css.gz \
                              .ics.gz \
                              .js.gz \
                              .json.gz
         </IfModule>
 
-        # Force proxies to cache gzipped and non-gzipped files separately.
+        # Force proxies to cache gzipped and non-gzipped files separately
         Header append Vary Accept-Encoding
 
     </FilesMatch>
 
-    # Serve correct encoding type.
+    # Serve correct encoding type
     AddEncoding gzip .gz
 
 </IfModule>

--- a/src/web_performance/serving_pre-compressed_content.conf
+++ b/src/web_performance/serving_pre-compressed_content.conf
@@ -1,0 +1,57 @@
+# ----------------------------------------------------------------------
+# | Serving pre-compressed content                                     |
+# ----------------------------------------------------------------------
+
+<IfModule mod_headers.c>
+
+    # Serve brotli compressed CSS, JS, HTML, SVG, ICS and JSON files if they exist
+    # and the client accepts br.
+    RewriteCond "%{HTTP:Accept-encoding}" "br"
+    RewriteCond "%{REQUEST_FILENAME}\.br" -s
+    RewriteRule ^(.+)\.(css|js|html|svg|ics|json)$ $1.$2.br [L]
+
+    # Serve correct content types, and prevent mod_deflate double gzip.
+    RewriteRule "\.css\.br$" "-" [T=text/css,E=no-gzip:1]
+    RewriteRule "\.js\.br$" "-" [T=text/javascript,E=no-gzip:1]
+    RewriteRule "\.html\.br$" "-" [T=text/html,E=no-gzip:1]
+    RewriteRule "\.svg\.br$" "-" [T=image/svg+xml,E=no-gzip:1]
+    RewriteRule "\.ics\.br$" "-" [T=text/calendar,E=no-gzip:1]
+    RewriteRule "\.json\.br$" "-" [T=text/json,E=no-gzip:1]
+
+    <FilesMatch "(\.js\.br|\.css\.br|\.html\.br|\.svg\.br|\.ics\.br|\.json\.br)$">
+      # Serve correct encoding type.
+      Header append Content-Encoding br
+
+      # Force proxies to cache gzipped &
+      # non-brotlied css/js files separately.
+      Header append Vary Accept-Encoding
+    </FilesMatch>
+
+</IfModule>
+
+<IfModule mod_headers.c>
+
+    # Serve gzip compressed CSS, JS, HTML, SVG, ICS and JSON files if they exist
+    # and the client accepts gzip.
+    RewriteCond "%{HTTP:Accept-encoding}" "gzip"
+    RewriteCond "%{REQUEST_FILENAME}\.gz" -s
+    RewriteRule ^(.+)\.(css|js|html|svg|ics|json)$ $1.$2.gz [L]
+
+    # Serve correct content types, and prevent mod_deflate double gzip.
+    RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
+    RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1]
+    RewriteRule "\.html\.gz$" "-" [T=text/html,E=no-gzip:1]
+    RewriteRule "\.svg\.gz$" "-" [T=image/svg+xml,E=no-gzip:1]
+    RewriteRule "\.ics\.gz$" "-" [T=text/calendar,E=no-gzip:1]
+    RewriteRule "\.json\.gz$" "-" [T=text/json,E=no-gzip:1]
+
+    <FilesMatch "(\.js\.gz|\.css\.gz|\.html\.gz|\.svg\.gz|\.ics\.gz|\.json\.gz)$">
+      # Serve correct encoding type.
+      Header append Content-Encoding gzip
+
+      # Force proxies to cache gzipped &
+      # non-gzipped css/js files separately.
+      Header append Vary Accept-Encoding
+    </FilesMatch>
+
+</IfModule>

--- a/src/web_performance/serving_pre-compressed_content.conf
+++ b/src/web_performance/serving_pre-compressed_content.conf
@@ -18,7 +18,7 @@
     RewriteRule "\.ics\.br$" "-" [T=text/calendar,E=no-gzip:1]
     RewriteRule "\.json\.br$" "-" [T=text/json,E=no-gzip:1]
 
-    <FilesMatch "(\.js\.br|\.css\.br|\.html\.br|\.svg\.br|\.ics\.br|\.json\.br)$">
+    <FilesMatch "\.br$">
       # Force proxies to cache gzipped &
       # non-brotlied css/js files separately.
       Header append Vary Accept-Encoding
@@ -45,7 +45,7 @@
     RewriteRule "\.ics\.gz$" "-" [T=text/calendar,E=no-gzip:1]
     RewriteRule "\.json\.gz$" "-" [T=text/json,E=no-gzip:1]
 
-    <FilesMatch "(\.js\.gz|\.css\.gz|\.html\.gz|\.svg\.gz|\.ics\.gz|\.json\.gz)$">
+    <FilesMatch "\.gz$">
       # Force proxies to cache gzipped &
       # non-gzipped css/js files separately.
       Header append Vary Accept-Encoding

--- a/src/web_performance/serving_pre-compressed_content.conf
+++ b/src/web_performance/serving_pre-compressed_content.conf
@@ -6,9 +6,9 @@
 
     # Serve brotli compressed CSS, JS, HTML, SVG, ICS and JSON files if they exist
     # and the client accepts br.
-    RewriteCond "%{HTTP:Accept-encoding}" "br"
-    RewriteCond "%{REQUEST_FILENAME}\.br" -s
-    RewriteRule ^(.+)\.(css|js|html|svg|ics|json)$ $1.$2.br [L]
+    RewriteCond %{HTTP:Accept-Encoding} br
+    RewriteCond %{REQUEST_FILENAME}\.br -f
+    RewriteRule \.(css|js|html|svg|ics|json)$ %{REQUEST_URI}.br [L]
 
     # Serve correct content types, and prevent mod_deflate double gzip.
     RewriteRule "\.css\.br$" "-" [T=text/css,E=no-gzip:1]
@@ -19,13 +19,13 @@
     RewriteRule "\.json\.br$" "-" [T=text/json,E=no-gzip:1]
 
     <FilesMatch "(\.js\.br|\.css\.br|\.html\.br|\.svg\.br|\.ics\.br|\.json\.br)$">
-      # Serve correct encoding type.
-      Header append Content-Encoding br
-
       # Force proxies to cache gzipped &
       # non-brotlied css/js files separately.
       Header append Vary Accept-Encoding
     </FilesMatch>
+
+    # Serve correct encoding type.
+    AddEncoding br .br
 
 </IfModule>
 
@@ -33,9 +33,9 @@
 
     # Serve gzip compressed CSS, JS, HTML, SVG, ICS and JSON files if they exist
     # and the client accepts gzip.
-    RewriteCond "%{HTTP:Accept-encoding}" "gzip"
-    RewriteCond "%{REQUEST_FILENAME}\.gz" -s
-    RewriteRule ^(.+)\.(css|js|html|svg|ics|json)$ $1.$2.gz [L]
+    RewriteCond %{HTTP:Accept-Encoding} gzip
+    RewriteCond %{REQUEST_FILENAME}\.gz -f
+    RewriteRule \.(css|js|html|svg|ics|json)$ %{REQUEST_URI}.gz [L]
 
     # Serve correct content types, and prevent mod_deflate double gzip.
     RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
@@ -46,12 +46,12 @@
     RewriteRule "\.json\.gz$" "-" [T=text/json,E=no-gzip:1]
 
     <FilesMatch "(\.js\.gz|\.css\.gz|\.html\.gz|\.svg\.gz|\.ics\.gz|\.json\.gz)$">
-      # Serve correct encoding type.
-      Header append Content-Encoding gzip
-
       # Force proxies to cache gzipped &
       # non-gzipped css/js files separately.
       Header append Vary Accept-Encoding
     </FilesMatch>
+
+    # Serve correct encoding type.
+    AddEncoding gzip .gz
 
 </IfModule>

--- a/test/fixtures/test-pre-brotli.js
+++ b/test/fixtures/test-pre-brotli.js
@@ -1,0 +1,1 @@
+raw-content

--- a/test/fixtures/test-pre-brotli.js.br
+++ b/test/fixtures/test-pre-brotli.js.br
@@ -1,0 +1,1 @@
+brotli-content

--- a/test/fixtures/test-pre-gzip.js
+++ b/test/fixtures/test-pre-gzip.js
@@ -1,0 +1,1 @@
+raw-content

--- a/test/fixtures/test-pre-gzip.js.gz
+++ b/test/fixtures/test-pre-gzip.js.gz
@@ -1,0 +1,1 @@
+gzip-content

--- a/test/htaccess_fixture.conf
+++ b/test/htaccess_fixture.conf
@@ -83,6 +83,8 @@ enable  "src/security/server_software_information.conf"
 
 title   "web performance"
 enable  "src/web_performance/compression.conf"
+enable  "src/web_performance/pre-compressed_content_brotli.conf"
+enable  "src/web_performance/pre-compressed_content_gzip.conf"
 enable  "src/web_performance/content_transformation.conf"
 enable  "src/web_performance/etags.conf"
 enable  "src/web_performance/expires_headers.conf"

--- a/test/tests.js
+++ b/test/tests.js
@@ -842,6 +842,36 @@ exports = module.exports = {
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         {
+            description: 'Test if files are served compressed using precompressed files',
+            files: {
+
+                'test-pre-gzip.js': {
+                    responseHeaders: {
+                        'cache-control': 'max-age=31536000, no-transform',
+                        'content-encoding': 'gzip',
+                        'content-type': 'text/javascript; charset=utf-8'
+                    },
+                    responseBody: 'gzip-content\n'
+                },
+
+                'test-pre-brotli.js': {
+                    requestHeaders: {
+                        'accept-encoding': 'br'
+                    },
+                    responseHeaders: {
+                        'cache-control': 'max-age=31536000, no-transform',
+                        'content-encoding': 'br',
+                        'content-type': 'text/javascript; charset=utf-8'
+                    },
+                    responseBody: 'brotli-content\n'
+                }
+
+            }
+        },
+
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        {
             description: 'Test if filename-based cache busting works',
             files: {
 


### PR DESCRIPTION
Hi again,
after https://github.com/h5bp/server-configs-apache/issues/134 I finally got free time to open a PR.

This PR is not finished yet. In fact it is working for my server setup, but I think it needs more input about how to combine `br` and `gz` section properly.

Until now only `css|js|html|svg|ics|json` precompressed files are served. I guess we should support all non-binary files here.

Thanks for your help and have a nice day
midzer

---
Fix #134 and fix #105 and close #113 as per https://github.com/h5bp/server-configs-apache/issues/105#issuecomment-363739736