### PR TITLE
Add WebAssembly module MIME type

### DIFF
--- a/src/files_match_pattern
+++ b/src/files_match_pattern
@@ -45,6 +45,7 @@ txt
 vcard
 vcf
 vtt
+wasm
 webapp
 web[mp]
 webmanifest

--- a/src/media_types/media_types.conf
+++ b/src/media_types/media_types.conf
@@ -53,6 +53,11 @@
     AddType image/x-icon                                cur ico
 
 
+  # WebAssembly
+
+    AddType application/wasm                            wasm
+
+
   # Web fonts
 
     AddType font/woff                                   woff

--- a/src/web_performance/compression.conf
+++ b/src/web_performance/compression.conf
@@ -30,6 +30,7 @@
                                       "application/schema+json" \
                                       "application/vnd.geo+json" \
                                       "application/vnd.ms-fontobject" \
+                                      "application/wasm" \
                                       "application/x-font-ttf" \
                                       "application/x-javascript" \
                                       "application/x-web-app-manifest+json" \

--- a/src/web_performance/expires_headers.conf
+++ b/src/web_performance/expires_headers.conf
@@ -78,6 +78,11 @@
     ExpiresByType video/webm                            "access plus 1 month"
 
 
+  # WebAssembly
+
+    ExpiresByType application/wasm                      "access plus 1 year"
+
+
   # Web fonts
 
     # Collection

--- a/test/fixtures/test.wasm
+++ b/test/fixtures/test.wasm
@@ -1,0 +1,6 @@
+#define WASM_EXPORT __attribute__((visibility("default")))
+
+WASM_EXPORT
+int test(int n) {
+  return n;
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -485,6 +485,13 @@ exports = module.exports = {
                     }
                 },
 
+                'test.wasm': {
+                    responseHeaders: {
+                        'cache-control': 'max-age=31536000, no-transform',
+                        'content-type': 'application/wasm'
+                    }
+                },
+
                 'test.webapp': {
                     responseHeaders: {
                         'cache-control': 'max-age=0, no-transform',


### PR DESCRIPTION
Ref:
* https://webassembly.github.io/spec/core/binary/conventions.html
* https://developers.google.com/web/updates/2018/04/loading-wasm
* https://github.com/jshttp/mime-db/pull/97
* https://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#web-server-setup

fix #145

---
I'm not really sure if we should add the content charset... Someone?