### PR TITLE
Fix 404 Link For "Pushing Beyond Gzipping" Article by Marcel Duran

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -781,7 +781,7 @@ ServerSignature Off
 <IfModule mod_deflate.c>
 
     # Force compression for mangled `Accept-Encoding` request headers
-    # https://developer.yahoo.com/blogs/ydn/pushing-beyond-gzipping-25601.html
+    # https://calendar.perfplanet.com/2010/pushing-beyond-gzipping/
 
     <IfModule mod_setenvif.c>
         <IfModule mod_headers.c>

--- a/src/web_performance/compression.conf
+++ b/src/web_performance/compression.conf
@@ -5,7 +5,7 @@
 <IfModule mod_deflate.c>
 
     # Force compression for mangled `Accept-Encoding` request headers
-    # https://developer.yahoo.com/blogs/ydn/pushing-beyond-gzipping-25601.html
+    # https://calendar.perfplanet.com/2010/pushing-beyond-gzipping/
 
     <IfModule mod_setenvif.c>
         <IfModule mod_headers.c>


### PR DESCRIPTION
404 Link: https://developer.yahoo.com/blogs/ydn/pushing-beyond-gzipping-25601.html
Web Archive Version: https://web.archive.org/web/20160729061300/https://developer.yahoo.com/blogs/ydn/pushing-beyond-gzipping-25601.html
Original: https://calendar.perfplanet.com/2010/pushing-beyond-gzipping/

Closes https://github.com/h5bp/server-configs-apache/issues/150