### PR TITLE
Allow SSL certificate set up over HTTP

### DIFF
--- a/src/rewrites/rewrite_http_to_https.conf
+++ b/src/rewrites/rewrite_http_to_https.conf
@@ -18,7 +18,7 @@
    RewriteEngine On
    RewriteCond %{HTTPS} !=on
    # (1)
-   # RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+   # RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/
    # RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
    # RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]

--- a/src/rewrites/rewrite_http_to_https.conf
+++ b/src/rewrites/rewrite_http_to_https.conf
@@ -9,5 +9,8 @@
 <IfModule mod_rewrite.c>
    RewriteEngine On
    RewriteCond %{HTTPS} !=on
+   RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+   RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+   RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </IfModule>

--- a/src/rewrites/rewrite_http_to_https.conf
+++ b/src/rewrites/rewrite_http_to_https.conf
@@ -19,7 +19,7 @@
    RewriteCond %{HTTPS} !=on
    # (1)
    # RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/
-   # RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+   # RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[\w-]+$
    # RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </IfModule>

--- a/src/rewrites/rewrite_http_to_https.conf
+++ b/src/rewrites/rewrite_http_to_https.conf
@@ -6,11 +6,19 @@
 #
 # https://wiki.apache.org/httpd/RewriteHTTPToHTTPS
 
+# (1) If you're using cPanel AutoSSL or the Let's Encrypt webroot
+#     method it will fail to validate the certificate if validation 
+#     requests are redirected to HTTPS. Turn on the condition(s) 
+#     you need.
+#
+#     https://github.com/h5bp/server-configs-apache/pull/157
+
 <IfModule mod_rewrite.c>
    RewriteEngine On
    RewriteCond %{HTTPS} !=on
-   RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
-   RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
-   RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
+   # (1)
+   # RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+   # RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+   # RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </IfModule>

--- a/src/rewrites/rewrite_http_to_https.conf
+++ b/src/rewrites/rewrite_http_to_https.conf
@@ -11,7 +11,8 @@
 #     requests are redirected to HTTPS. Turn on the condition(s) 
 #     you need.
 #
-#     https://github.com/h5bp/server-configs-apache/pull/157
+#     https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml
+#     https://tools.ietf.org/html/draft-ietf-acme-acme-12
 
 <IfModule mod_rewrite.c>
    RewriteEngine On


### PR DESCRIPTION
A non-HTTPS connection is required in some cases.