### PR TITLE
Update pre-compressed_content_brotli.conf

### DIFF
--- a/src/web_performance/pre-compressed_content_brotli.conf
+++ b/src/web_performance/pre-compressed_content_brotli.conf
@@ -5,9 +5,11 @@
 # Serve brotli compressed CSS, JS, HTML, SVG, ICS and JSON files
 # if they exist and if the client accepts br encoding.
 #
-# (!) To make this part relevant, you need to generate encoded
-# files by your own. Enabling this part will not auto-generate
-# brotlied files.
+# (!) To make this part relevant, you need to:
+# 1. Serve the website over a secure connection (Brotli requires 
+# `https://`).
+# 2. Generate encoded files by your own. Enabling this part will not 
+# auto-generate brotlied files.
 #
 # https://httpd.apache.org/docs/current/mod/mod_brotli.html#precompressed
 


### PR DESCRIPTION
**Brotli requires https**, adding a note on that.

Indications to back up that statement:
https://groups.google.com/forum/#!topic/brotli/fN6M9A8aRnM
https://www.chromestatus.com/feature/5420797577396224

If this PR is merged, do I also have to add this to `dist/.htaccess` or is that built from the source files?