### PR TITLE
Update trace_method.conf

### DIFF
--- a/src/security/trace_method.conf
+++ b/src/security/trace_method.conf
@@ -10,26 +10,17 @@
 # Modern browsers now prevent TRACE requests being made via JavaScript,
 # however, other ways of sending TRACE requests with browsers have been
 # discovered, such as using Java.
-
-# Disallow TRACE HTTP Method:
 #
 # (!) If you have access to the main server configuration file, use the 
-# `TraceEnable` directive instead.
-
-<IfModule mod_rewrite.c>
-    RewriteEngine On
-    RewriteCond %{REQUEST_METHOD} ^TRACE [NC]
-    RewriteRule .* - [R=405,L]
-</IfModule>
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-# (!) The `TraceEnable` directive will only work in the main server
-# configuration file, so don't try to enable it in the `.htaccess` file!
+#     `TraceEnable` directive instead.
 #
 # https://tools.ietf.org/html/rfc7231#section-4.3.8
 # https://www.owasp.org/index.php/Cross_Site_Tracing
 # https://www.owasp.org/index.php/Test_HTTP_Methods_(OTG-CONFIG-006)
 # https://httpd.apache.org/docs/current/mod/core.html#traceenable
 
-TraceEnable Off
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{REQUEST_METHOD} ^TRACE [NC]
+    RewriteRule .* - [R=405,L]
+</IfModule>

--- a/src/security/trace_method.conf
+++ b/src/security/trace_method.conf
@@ -18,7 +18,7 @@
 
 <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteCond %{REQUEST_METHOD} ^(TRACE) [NC]
+    RewriteCond %{REQUEST_METHOD} ^TRACE [NC]
     RewriteRule .* - [R=405,L]
 </IfModule>
 
@@ -32,4 +32,4 @@
 # https://www.owasp.org/index.php/Test_HTTP_Methods_(OTG-CONFIG-006)
 # https://httpd.apache.org/docs/current/mod/core.html#traceenable
 
-# TraceEnable Off
+TraceEnable Off

--- a/src/security/trace_method.conf
+++ b/src/security/trace_method.conf
@@ -5,12 +5,25 @@
 # Prevent Apache from responding to `TRACE` HTTP request.
 #
 # The TRACE method, while apparently harmless, can be successfully
-# leveraged in some scenarios to steal legitimate users' credentials
+# leveraged in some scenarios to steal legitimate users' credentials.
 #
 # Modern browsers now prevent TRACE requests being made via JavaScript,
 # however, other ways of sending TRACE requests with browsers have been
 # discovered, such as using Java.
+
+# Disallow TRACE HTTP Method:
 #
+# (!) If you have access to the main server configuration file, use the 
+# `TraceEnable` directive instead.
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{REQUEST_METHOD} ^(TRACE) [NC]
+    RewriteRule .* - [R=405,L]
+</IfModule>
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 # (!) The `TraceEnable` directive will only work in the main server
 # configuration file, so don't try to enable it in the `.htaccess` file!
 #
@@ -19,4 +32,4 @@
 # https://www.owasp.org/index.php/Test_HTTP_Methods_(OTG-CONFIG-006)
 # https://httpd.apache.org/docs/current/mod/core.html#traceenable
 
-TraceEnable Off
+# TraceEnable Off


### PR DESCRIPTION
For consistency - similarly to [`ServerTokens Prod`](https://github.com/h5bp/server-configs-apache/blob/master/src/security/server_software_information.conf) which is only available from the main server config file, the `TraceEnable` directive shouldn't be enabled by default. 

This PR adds an alternative method for disallowing `TRACE` from `.htaccess` instead, which is enabled by default.