### PR TITLE
[CSP] enhancements to example policy

### DIFF
--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -8,18 +8,69 @@
 # This can be done by setting a `Content Security Policy` which
 # whitelists trusted sources of content for your website.
 #
-# The example header below allows ONLY scripts that are loaded from
-# the current website's origin (no inline scripts, no CDN, etc).
-# That almost certainly won't work as-is for your website!
+# There is no one policy that fits all websites, you will have to modify
+# the `Content-Security-Policy` directives in the example below depending
+# on your needs.
 #
-# To make things easier, you can use an online CSP header generator
-# such as: https://www.cspisawesome.com/.
+# The example policy below ensures that:
 #
+#  (1) The `<base>` element is not allowed on the website. This is to
+#      prevent attackers from changing the locations of resources loaded
+#      from relative URLs.
+#
+#      If you want to use the `<base>` element, then `base-uri 'self'`
+#      can be used instead.
+#
+#  (2) All resources are restricted to the origin of the current website
+#      by setting the `default-src` directive to `'self'` - which acts as a
+#      fallback to all "Fetch directives" (https://developer.mozilla.org/en-US/docs/Glossary/Fetch_directive).
+#
+#      This is conveniant as you do not have to specify all Fetch directives
+#      that apply to your site, for example:
+#      `connect-src 'self'; font-src 'self'; script-src 'self'; style-src 'self'`, etc.
+#
+#      This restriction also means that you must explicitly define from
+#      which site(s) your website is allowed to load resources from.
+#
+#  (3) Scripts are only allowed to be loaded from the current website
+#      and an example CDN website.
+#
+#  (4) Form submissions are only allowed from the current website by
+#      setting: `form-action 'self'`.
+#
+#  (5) Prevents other websites to embed your website with e.g. the
+#      `<iframe>` or `<object>` element, by setting `frame-ancestors 'self'`.
+#
+#	   The `frame-ancestors` directive helps avoid "Clickjacking" attacks
+#      and is similar to the `X-Frame-Options` header.
+#
+#      Browsers that support the CSP header will ignore `X-Frame-Options`
+#      if `frame-ancestors` is also specified.
+#
+#  (6) Forces the browser to treat all the resources that are served over
+#      HTTP as if they were loaded securely over HTTPS by setting the
+#      `upgrade-insecure-requests` directive.
+#
+#      Please note that `upgrade-insecure-requests` does not ensure
+#      HTTPS for the top-level navigation. If you want to force the
+#      website itself to be loaded over HTTPS you must include the
+#      `Strict-Transport-Security` header.
+#
+# To make your CSP implementation easier, you can use an online CSP header
+# generator such as:
+# https://www.cspisawesome.com/
+# https://report-uri.com/home/generate/.
+#
+# It is encouraged that you validate your CSP header using a CSP validator
+# such as:
+# https://csp-evaluator.withgoogle.com
+#
+# https://csp.withgoogle.com/docs/
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
-# https://www.w3.org/TR/CSP3/
-# https://content-security-policy.com/
 # https://www.html5rocks.com/en/tutorials/security/content-security-policy/
+# https://www.w3.org/TR/CSP/
 
 <IfModule mod_headers.c>
-    Header set Content-Security-Policy "script-src 'self'; object-src 'self'" "expr=%{CONTENT_TYPE} =~ m#text/html#i"
+    #                                   (1)              (2)                 (3)                                        (4)                 (5)                     (6)
+    Header set Content-Security-Policy "base-uri 'none'; default-src 'self'; script-src 'self' https://cdn.example.com; form-action 'self'; frame-ancestors 'self'; upgrade-insecure-requests" "expr=%{CONTENT_TYPE} =~ m#text/html#i"
 </IfModule>

--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -18,7 +18,7 @@
 #      by setting the `default-src` directive to `'self'` - which acts as a
 #      fallback to all "Fetch directives" (https://developer.mozilla.org/en-US/docs/Glossary/Fetch_directive).
 #
-#      This is conveniant as you do not have to specify all Fetch directives
+#      This is convenient as you do not have to specify all Fetch directives
 #      that apply to your site, for example:
 #      `connect-src 'self'; font-src 'self'; script-src 'self'; style-src 'self'`, etc.
 #

--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -8,7 +8,7 @@
 # This can be done by setting a `Content Security Policy` which
 # whitelists trusted sources of content for your website.
 #
-# There is no one policy that fits all websites, you will have to modify
+# There is no policy that fits all websites, you will have to modify
 # the `Content-Security-Policy` directives in the example below depending
 # on your needs.
 #

--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -58,7 +58,6 @@
 #
 # To make your CSP implementation easier, you can use an online CSP header
 # generator such as:
-# https://www.cspisawesome.com/
 # https://report-uri.com/home/generate/
 #
 # It is encouraged that you validate your CSP header using a CSP validator

--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -14,7 +14,7 @@
 #
 # The example policy below aims to:
 #
-#  (1) Restrict all fetches by default from the origin of the current website
+#  (1) Restrict all fetches by default to the origin of the current website
 #      by setting the `default-src` directive to `'self'` - which acts as a
 #      fallback to all "Fetch directives" (https://developer.mozilla.org/en-US/docs/Glossary/Fetch_directive).
 #

--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -59,7 +59,7 @@
 # To make your CSP implementation easier, you can use an online CSP header
 # generator such as:
 # https://www.cspisawesome.com/
-# https://report-uri.com/home/generate/.
+# https://report-uri.com/home/generate/
 #
 # It is encouraged that you validate your CSP header using a CSP validator
 # such as:

--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -12,9 +12,9 @@
 # the `Content-Security-Policy` directives in the example below depending
 # on your needs.
 #
-# The example policy below ensures that:
+# The example policy below aims to:
 #
-#  (1) All resources are restricted to the origin of the current website
+#  (1) Restrict all fetches by default from the origin of the current website
 #      by setting the `default-src` directive to `'self'` - which acts as a
 #      fallback to all "Fetch directives" (https://developer.mozilla.org/en-US/docs/Glossary/Fetch_directive).
 #
@@ -68,6 +68,6 @@
 # https://www.w3.org/TR/CSP/
 
 <IfModule mod_headers.c>
-    #                                   (1)                 (2)              (3)                 (4)                    (5)
+    #                                   (1)                 (2)              (3)                 (4)                     (5)
     Header set Content-Security-Policy "default-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" "expr=%{CONTENT_TYPE} =~ m#text/html#i"
 </IfModule>

--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -38,7 +38,7 @@
 #  (4) Form submissions are only allowed from the current website by
 #      setting: `form-action 'self'`.
 #
-#  (5) Prevents other websites to embed your website with e.g. the
+#  (5) Prevents other websites from embedding your website with e.g. the
 #      `<iframe>` or `<object>` element, by setting `frame-ancestors 'self'`.
 #
 #	   The `frame-ancestors` directive helps avoid "Clickjacking" attacks

--- a/src/security/content-security-policy.conf
+++ b/src/security/content-security-policy.conf
@@ -14,14 +14,7 @@
 #
 # The example policy below ensures that:
 #
-#  (1) The `<base>` element is not allowed on the website. This is to
-#      prevent attackers from changing the locations of resources loaded
-#      from relative URLs.
-#
-#      If you want to use the `<base>` element, then `base-uri 'self'`
-#      can be used instead.
-#
-#  (2) All resources are restricted to the origin of the current website
+#  (1) All resources are restricted to the origin of the current website
 #      by setting the `default-src` directive to `'self'` - which acts as a
 #      fallback to all "Fetch directives" (https://developer.mozilla.org/en-US/docs/Glossary/Fetch_directive).
 #
@@ -32,14 +25,19 @@
 #      This restriction also means that you must explicitly define from
 #      which site(s) your website is allowed to load resources from.
 #
-#  (3) Scripts are only allowed to be loaded from the current website
-#      and an example CDN website.
+#  (2) The `<base>` element is not allowed on the website. This is to
+#      prevent attackers from changing the locations of resources loaded
+#      from relative URLs.
 #
-#  (4) Form submissions are only allowed from the current website by
+#      If you want to use the `<base>` element, then `base-uri 'self'`
+#      can be used instead.
+#
+#  (3) Form submissions are only allowed from the current website by
 #      setting: `form-action 'self'`.
 #
-#  (5) Prevents other websites from embedding your website with e.g. the
-#      `<iframe>` or `<object>` element, by setting `frame-ancestors 'self'`.
+#  (4) Prevents all websites (including your own) from embedding your
+#      webpages within e.g. the `<iframe>` or `<object>` element by
+#      setting `frame-ancestors 'none'`.
 #
 #	   The `frame-ancestors` directive helps avoid "Clickjacking" attacks
 #      and is similar to the `X-Frame-Options` header.
@@ -47,7 +45,7 @@
 #      Browsers that support the CSP header will ignore `X-Frame-Options`
 #      if `frame-ancestors` is also specified.
 #
-#  (6) Forces the browser to treat all the resources that are served over
+#  (5) Forces the browser to treat all the resources that are served over
 #      HTTP as if they were loaded securely over HTTPS by setting the
 #      `upgrade-insecure-requests` directive.
 #
@@ -70,6 +68,6 @@
 # https://www.w3.org/TR/CSP/
 
 <IfModule mod_headers.c>
-    #                                   (1)              (2)                 (3)                                        (4)                 (5)                     (6)
-    Header set Content-Security-Policy "base-uri 'none'; default-src 'self'; script-src 'self' https://cdn.example.com; form-action 'self'; frame-ancestors 'self'; upgrade-insecure-requests" "expr=%{CONTENT_TYPE} =~ m#text/html#i"
+    #                                   (1)                 (2)              (3)                 (4)                    (5)
+    Header set Content-Security-Policy "default-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" "expr=%{CONTENT_TYPE} =~ m#text/html#i"
 </IfModule>


### PR DESCRIPTION
Fix #156

Also, with these changes the CSP `frame-ancestors` directive description now mentions the relation to `X-Frame-Options`  (https://w3c.github.io/webappsec-csp/#frame-ancestors-and-frame-options). Seems logical `X-Frame-Options` should say something about `frame-ancestors`/CSP? I can probably do that tomorrow, really tired atm. :)