### PR TITLE
Always unset X-Powered-By header

### DIFF
--- a/src/security/x-powered-by.conf
+++ b/src/security/x-powered-by.conf
@@ -22,7 +22,4 @@
 # Note you need both below as the "always" option doesn't always work with some servers for some reasons.
 <IfModule mod_headers.c>
     Header always unset X-Powered-By
-    Header unset X-Powered-By  
 </IfModule>
-
-

--- a/src/security/x-powered-by.conf
+++ b/src/security/x-powered-by.conf
@@ -18,8 +18,6 @@
 #
 # https://php.net/manual/en/ini.core.php#ini.expose-php
 
-
-# Note you need both below as the "always" option doesn't always work with some servers for some reasons.
 <IfModule mod_headers.c>
     Header always unset X-Powered-By
 </IfModule>

--- a/src/security/x-powered-by.conf
+++ b/src/security/x-powered-by.conf
@@ -18,6 +18,11 @@
 #
 # https://php.net/manual/en/ini.core.php#ini.expose-php
 
+
+# Note you need both below as the "always" option doesn't always work with some servers for some reasons.
 <IfModule mod_headers.c>
-    Header unset X-Powered-By
+    Header always unset X-Powered-By
+    Header unset X-Powered-By  
 </IfModule>
+
+


### PR DESCRIPTION
as per #183, `always` can be used to ensure the directive is always applied. In this case should be a sensed default. Also as found [here](https://www.tunetheweb.com/security/http-security-headers/server-header/) a good default is to use both versions since the `always` option is reported as not always working in some server configurations.

Fix #183 