### PR TITLE
Content Transformation: Update link to RFC, add mentions of Lite Mode

### DIFF
--- a/src/web_performance/content_transformation.conf
+++ b/src/web_performance/content_transformation.conf
@@ -3,11 +3,11 @@
 # ----------------------------------------------------------------------
 
 # Prevent intermediate caches or proxies (e.g.: such as the ones
-# used by mobile network providers) from modifying the website's
-# content.
+# used by mobile network providers) and browser features such as Google's
+# "Lite Mode" from modifying the website's content.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-# https://tools.ietf.org/html/rfc2616#section-14.9.5
+# https://tools.ietf.org/html/rfc7234#section-5.2.2.4
 #
 # (!) If you are using `mod_pagespeed`, please note that setting
 # the `Cache-Control: no-transform` response header will prevent
@@ -16,6 +16,11 @@
 # to `off`, also from rewriting other resources.
 #
 # https://developers.google.com/speed/pagespeed/module/configuration#notransform
+#
+# (!) You can test the effects of content transformation applied by
+# Google's Lite Mode by visiting: https://googleweblight.com/i?u=https://www.example.com
+#
+# https://support.google.com/webmasters/answer/6211428?hl=en
 
 <IfModule mod_headers.c>
     Header merge Cache-Control "no-transform"

--- a/src/web_performance/content_transformation.conf
+++ b/src/web_performance/content_transformation.conf
@@ -9,7 +9,7 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 # https://tools.ietf.org/html/rfc7234#section-5.2.2.4
 #
-# (!) Carefully consider the impact of your visitors before disabling
+# (!) Carefully consider the impact on your visitors before disabling
 #     content transformation. These transformations are performed to 
 #     improve the experience for data- and cost-constrained users
 #     (e.g. users on a 2G connection).

--- a/src/web_performance/content_transformation.conf
+++ b/src/web_performance/content_transformation.conf
@@ -2,25 +2,29 @@
 # | Content transformation                                             |
 # ----------------------------------------------------------------------
 
-# Prevent intermediate caches or proxies (e.g.: such as the ones
-# used by mobile network providers) and browser features such as Google's
-# "Lite Mode" from modifying the website's content.
+# Prevent intermediate caches or proxies (such as those used by mobile
+# network providers) and browsers data-saving features from modifying
+# the website's content using the `cache-control: no-transform` directive.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 # https://tools.ietf.org/html/rfc7234#section-5.2.2.4
 #
-# (!) If you are using `mod_pagespeed`, please note that setting
-# the `Cache-Control: no-transform` response header will prevent
-# `PageSpeed` from rewriting `HTML` files, and, if the
-# `ModPagespeedDisableRewriteOnNoTransform` directive isn't set
-# to `off`, also from rewriting other resources.
+# (!) Carefully consider the impact of your visitors before disabling
+#     content transformation. These transformations are performed to 
+#     improve the experience for data- and cost-constrained users
+#     (e.g. users on a 2G connection).
 #
-# https://developers.google.com/speed/pagespeed/module/configuration#notransform
+#     You can test the effects of content transformation applied by 
+#     Google's Lite Mode by visiting: https://googleweblight.com/i?u=https://www.example.com
 #
-# (!) You can test the effects of content transformation applied by
-# Google's Lite Mode by visiting: https://googleweblight.com/i?u=https://www.example.com
+#     https://support.google.com/webmasters/answer/6211428
 #
-# https://support.google.com/webmasters/answer/6211428?hl=en
+# (!) If you are using `mod_pagespeed`, note that disabling this will 
+#     prevent `PageSpeed` from rewriting HTML files, and, if the 
+#     `ModPagespeedDisableRewriteOnNoTransform` directive isn't set to 
+#     `off`, also from rewriting other resources.
+#
+#     https://developers.google.com/speed/pagespeed/module/configuration#notransform
 
 <IfModule mod_headers.c>
     Header merge Cache-Control "no-transform"


### PR DESCRIPTION
Changes motivated by https://github.com/h5bp/server-configs-apache/issues/185.

Closes #185 

<hr>

@LeoColomb 

https://github.com/h5bp/server-configs-apache/issues/185#issuecomment-476262268

> Side note: if we keep it, the rfc link needs to be updated to https://tools.ietf.org/html/rfc7234#section-5.2.1.6

That's the section under "Request Cache-Control Directives", we should use the section described under "Response Cache-Control Directives" which is https://tools.ietf.org/html/rfc7234#section-5.2.2.4, correct?