### PR TITLE
feat: add filename-based webp serving

### DIFF
--- a/src/web_performance/filename-based_webp_serving.conf
+++ b/src/web_performance/filename-based_webp_serving.conf
@@ -1,0 +1,24 @@
+# ----------------------------------------------------------------------
+# | Filename-based Serve WebP Copies                                   |
+# ----------------------------------------------------------------------
+
+# Serve WebP files to supported browsers when a matching .webp version of a
+# JPEG/PNG file exists on the server.
+#
+# https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/automating-image-optimization/#how-do-i-serve-webp
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+
+  # Check if browser support WebP images
+  RewriteCond %{HTTP_ACCEPT} image/webp
+
+  # Check if WebP replacement image exists
+  RewriteCond %{DOCUMENT_ROOT}/$1.webp -f
+
+  # Serve WebP image instead
+  RewriteRule (.+)\.(jpe?g|png)$ $1.webp [T=image/webp,E=accept:1]
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header append Vary Accept env=REDIRECT_accept
+</IfModule>


### PR DESCRIPTION
Serve WebP files to supported browsers when a matching .webp version of a JPEG/PNG file exists
on the server.

PS: Code copied from [Automating image optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/automating-image-optimization/#how-do-i-serve-webp) Article By Addy Osmani on Google Web Fundamentals