### PR TITLE
`Expect-CT` header (Certificate Transparency)

### DIFF
--- a/h5bp/security/expect-ct.conf
+++ b/h5bp/security/expect-ct.conf
@@ -1,0 +1,31 @@
+# ----------------------------------------------------------------------
+# | Expect-CT                                                          |
+# ----------------------------------------------------------------------
+
+# Opt-in to Certificate Transparency (CT).
+#
+# Certificate Transparency helps guard against several types of certificate-
+# based threats, including misissued certificates, maliciously acquired
+# certificates, and rogue CAs (Certificate Authorities).
+#
+# (!) When a site requires Certificate Transparency (using the `enforce`
+#     directive), they are requesting that the browser checks that any
+#     certificate for that site appears in public CT logs (1).
+#     If there are issues with certificates, the browser may display an
+#     error message to warn visitors against privacy issues.
+#
+# It is advised (2) to only serve the Expect-CT header over a secure
+# connection.
+#
+# (1) https://crt.sh/
+#     https://www.certificate-transparency.org/known-logs
+#
+# (2) https://httpwg.org/http-extensions/expect-ct.html#http-request-type
+#
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT
+# https://www.certificate-transparency.org/resources-for-site-owners
+# https://httpwg.org/http-extensions/expect-ct.html
+
+<IfModule mod_headers.c>
+    Header always set Expect-CT "max-age=86400; enforce" "expr=%{HTTPS} == 'on'"
+</IfModule>


### PR DESCRIPTION
This is a somewhat rough proposal, for [`Expect-CT`](https://httpwg.org/http-extensions/expect-ct.html). 

There's been no public discussion within this repo around Expect-CT, or if this is even needed - if it is deemed unwanted - that is completely fine. I'll perhaps need it myself anyways. :)