### PR TITLE
Default to HSTS only over secure connections

### DIFF
--- a/src/security/strict-transport-security.conf
+++ b/src/security/strict-transport-security.conf
@@ -21,8 +21,8 @@
 #     connect over HTTP.
 #
 # (1) Preloading Strict Transport Security.
-#     To submit your site for HSTS preloading, it is required that you:
-#     * ensure the `includeSubDomains` directive is specified
+#     To submit your site for HSTS preloading, it is required that:
+#     * the `includeSubDomains` directive is specified
 #     * the `preload` directive is specified
 #     * the `max-age` is specified with a value of at least 31536000 seconds (1 year).
 #     See deployment recommendations: https://hstspreload.org/#deployment-recommendations

--- a/src/security/strict-transport-security.conf
+++ b/src/security/strict-transport-security.conf
@@ -2,48 +2,39 @@
 # | HTTP Strict Transport Security (HSTS)                              |
 # ----------------------------------------------------------------------
 
-# Force client-side SSL redirection.
+# Force client-side TLS (Transport Layer Security) redirection.
 #
 # If a user types `example.com` in their browser, even if the server
 # redirects them to the secure version of the website, that still leaves
 # a window of opportunity (the initial HTTP connection) for an attacker
 # to downgrade or redirect the request.
 #
-# The following header ensures that browser will ONLY connect to your
+# The following header ensures that browser only connects to your
 # server via HTTPS, regardless of what the users type in the browser's
 # address bar.
 #
-# (!) Be aware that this, once published, is not revokable and you must ensure
-# being able to serve the site via SSL for the duration you've specified
-# in max-age. When you don't have a valid SSL connection (anymore) your
-# visitors will see a nasty error message even when attempting to connect
-# via simple HTTP.
+# (!) Be aware that Strict Transport Security is not revokable and you
+#     must ensure being able to serve the site over HTTPS for the duration
+#     you've specified in the `max-age` directive. When you don't have a
+#     valid TLS connection anymore (e.g. due to an expired TLS cerfiticate)
+#     your visitors will see a nasty error message even when attempting to
+#     connect over HTTP.
 #
-# (!) Remove the `includeSubDomains` optional directive if the website's
-# subdomains are not using HTTPS.
+# (1) Preloading Strict Transport Security.
+#     To submit your site for HSTS preloading, it is required that you:
+#     * ensure the `includeSubDomains` directive is specified
+#     * the `preload` directive is specified
+#     * the `max-age` is specified with a value of at least 31536000 seconds (1 year).
+#     See deployment recommendations: https://hstspreload.org/#deployment-recommendations
 #
-# (1) If you want to submit your site for HSTS preload (2) you must
-#     * ensure the `includeSubDomains` directive to be present
-#     * the `preload` directive to be specified
-#     * the `max-age` to be at least 31536000 seconds (1 year) according to the current status.
-#
-#     It is also advised (3) to only serve the HSTS header via a secure connection
-#     which can be done with either `env=https` or `"expr=%{HTTPS} == 'on'"` (4). The
-#     exact way depends on your environment and might just be tried.
-#
-# (2) https://hstspreload.org/
-# (3) https://tools.ietf.org/html/rfc6797#section-7.2
-# (4) https://stackoverflow.com/questions/24144552/how-to-set-hsts-header-from-htaccess-only-on-https/24145033#comment81632711_24145033
-#
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
 # https://tools.ietf.org/html/rfc6797#section-6.1
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
 # https://www.html5rocks.com/en/tutorials/security/transport-layer-security/
 # https://blogs.msdn.microsoft.com/ieinternals/2014/08/18/strict-transport-security/
+# https://hstspreload.org/
 
 <IfModule mod_headers.c>
-    Header always set Strict-Transport-Security "max-age=16070400; includeSubDomains"
-    # (1) or if HSTS preloading is desired (respect (2) for current requirements):
-    # Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" env=HTTPS
-    # (4) respectively… (respect (2) for current requirements):
+    Header always set Strict-Transport-Security "max-age=16070400; includeSubDomains" "expr=%{HTTPS} == 'on'"
+    # (1) Enable your site for HSTS preload inclusion.
     # Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" "expr=%{HTTPS} == 'on'"
 </IfModule>


### PR DESCRIPTION
Fix https://github.com/h5bp/server-configs-apache/issues/194.

Removes `ENV=https` example per https://github.com/h5bp/server-configs-apache/issues/194#issuecomment-508881332, and set `"expr=%{HTTPS} == 'on'"` as default.

Also replaces occurrences of "SSL" (Secure Socket Layer) with [TLS](https://tools.ietf.org/html/rfc8446) (Transport Layer Security) as [SSL is deprecated](https://tools.ietf.org/html/rfc7568).