### PR TITLE
Update `compression.conf` for typo fix

### DIFF
--- a/src/web_performance/compression.conf
+++ b/src/web_performance/compression.conf
@@ -70,7 +70,7 @@
     # (do note that this will NOT make Apache compress them!).
     #
     # If these files types would be served without an appropriate
-    # `Content-Enable` response header, client applications (e.g.:
+    # `Content-Encoding` response header, client applications (e.g.:
     # browsers) wouldn't know that they first need to uncompress
     # the response, and thus, wouldn't be able to understand the
     # content.


### PR DESCRIPTION
I believe `Content-Enable` is meant to say `Content-Encoding`?