### PR TITLE
Delete .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-dist/
-!dist/.htaccess
-test/


### PR DESCRIPTION
This is redundant since we use the files property in package.json

https://github.com/h5bp/server-configs-apache/blob/6bf8df6f5977c372ce81c91b1de5fa76321a7b44/package.json#L22

```
C:\Users\xmr\Desktop\server-configs-apache>npm pack --dry
npm notice
npm notice package: apache-server-configs@3.2.1
npm notice === Tarball Contents ===
npm notice 50.9kB dist/.htaccess
npm notice 577B   package.json
npm notice 12.6kB CHANGELOG.md
npm notice 12.2kB README.md
npm notice 1.1kB  LICENSE.txt
npm notice === Tarball Details ===
npm notice name:          apache-server-configs
npm notice version:       3.2.1
npm notice filename:      apache-server-configs-3.2.1.tgz
npm notice package size:  21.5 kB
npm notice unpacked size: 77.3 kB
npm notice shasum:        a7b715a4f9568ef12f7f839dece039e008892f21
npm notice integrity:     sha512-Y6r/BNFrrdllk[...]ZZkjmfpUPPHzg==
npm notice total files:   5
npm notice
apache-server-configs-3.2.1.tgz
```