### PR TITLE
Added systemd module to support CentOS

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -31,10 +31,11 @@ LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule rewrite_module modules/mod_rewrite.so
 
-# Systemd DSO required when available.
-<IfFile modules/mod_systemd.so>
-  LoadModule systemd_module modules/mod_systemd.so
-</IfFile>
+# Enables Systemd module when available.
+# Required on some operating systems.
+# <IfFile modules/mod_systemd.so>
+#   LoadModule systemd_module modules/mod_systemd.so
+# </IfFile>
 
 <IfModule mod_unixd.c>
     # Run as a unique, less privileged user for security reasons.

--- a/httpd.conf
+++ b/httpd.conf
@@ -30,6 +30,7 @@ LoadModule unixd_module modules/mod_unixd.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule systemd_module modules/mod_systemd.so
 
 <IfModule mod_unixd.c>
     # Run as a unique, less privileged user for security reasons.

--- a/httpd.conf
+++ b/httpd.conf
@@ -30,7 +30,11 @@ LoadModule unixd_module modules/mod_unixd.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule rewrite_module modules/mod_rewrite.so
-LoadModule systemd_module modules/mod_systemd.so
+
+# Systemd DSO required when available.
+<IfFile modules/mod_systemd.so>
+  LoadModule systemd_module modules/mod_systemd.so
+</IfFile>
 
 <IfModule mod_unixd.c>
     # Run as a unique, less privileged user for security reasons.


### PR DESCRIPTION
CentOS requires `systemd` module to interact with `httpd` service otherwise it will shutdown gracefully leaving error in log:

> caught SIGWINCH, shutting down gracefully