### PR TITLE
apache error notification

### DIFF
--- a/h5bp/ssl/ssl_engine.conf
+++ b/h5bp/ssl/ssl_engine.conf
@@ -15,6 +15,9 @@
 #     By enabling a cache, we tell the client to re-use the already
 #     negotiated state.
 
+# Note: only information since mod_socache_shmcb is not loaded inside 
+# <VirtualHost *: 443> ... </VirtualHost> it can only be loaded outside of it.
+
 <IfModule mod_ssl.c>
 
     # (1)
@@ -26,9 +29,9 @@
     SSLSessionTickets Off
 
     # (3)
-    <IfModule mod_socache_shmcb.c>
-        SSLSessionCache "shmcb:/usr/local/apache2/logs/ssl_gcache_data(10485760)"
-        SSLSessionCacheTimeout 86400
-    </IfModule>
-
+    # <IfModule mod_socache_shmcb.c>
+    #    SSLSessionCache "shmcb:/usr/local/apache2/logs/ssl_gcache_data(10485760)"
+    #    SSLSessionCacheTimeout 86400
+    # </IfModule>
+ 
 </IfModule>


### PR DESCRIPTION
Perform a small test with the templates in vhosts / templates / example.com.conf and the file .000-default.conf and apache and if I get a result of notification of denial of loading.
read the documentation and it is only loaded in httpd and outside the virtualhost tags.
(x_x) I'm new to the subject and I'm learning.