### PR TITLE
Disable XSS Protection to avoid reflection attacks

### DIFF
--- a/h5bp/security/x-xss-protection.conf
+++ b/h5bp/security/x-xss-protection.conf
@@ -31,11 +31,10 @@
 #     being: validating and sanitizing your website's inputs.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
-# https://blogs.msdn.microsoft.com/ie/2008/07/02/ie8-security-part-iv-the-xss-filter/
-# https://blogs.msdn.microsoft.com/ieinternals/2011/01/31/controlling-the-xss-filter/
+# https://stackoverflow.com/a/57802070
 # https://www.owasp.org/index.php/Cross-site_Scripting_%28XSS%29
 
 <IfModule mod_headers.c>
     #                           (1)    (2)
-    Header always set X-XSS-Protection "1; mode=block" "expr=%{CONTENT_TYPE} =~ m#text/html#i"
+    Header always set X-XSS-Protection "0" "expr=%{CONTENT_TYPE} =~ m#text/html#i"
 </IfModule>


### PR DESCRIPTION
Reference: https://github.com/h5bp/server-configs-nginx/pull/260 and https://github.com/h5bp/server-configs-test/pull/87


See https://stackoverflow.com/a/57802070

> **TL;DR**: All well written web sites (/apps) must emit the header X-XSS-Protection: 0 and just forget about this feature. If you want to have extra security that better user agents can provide, use a strict Content-Security-Policy header.

> X-XSS-Protection: 1; mode=block allows attacker to leak data from the page source by using the behavior of the page as side-channel. For example, if the page contains JavaScript code along the lines of var csrf_secret="521231347843", the attacker simply adds an extra parameter e.g. leak=var%20csrf_secret="3 and if the page is NOT blocked, the 3 was incorrect first digit. The attacker tries again, this time leak=var%20csrf_secret="5 and the page loading will be aborted. This allows the attacker to know that the first digit of the secret is 5. The attacker then continues to guess the next digit. This allows easily brute-forcing of CSRF secrets or any other secret value in the <script> source.

