### PR TITLE
Add php expiration for no cache

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -1102,6 +1102,11 @@ FileETag None
     ExpiresByType text/html                             "access plus 0 seconds"
 
 
+  # PHP
+
+    ExpiresByType application/x-httpd-php               "access plus 0 seconds"
+
+
   # JavaScript
 
     ExpiresByType application/javascript                "access plus 1 year"

--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -45,6 +45,9 @@
 
     ExpiresByType text/html                             "access plus 0 seconds"
 
+  # PHP
+
+    ExpiresByType application/x-httpd-php               "access plus 0 seconds"
 
   # JavaScript
 


### PR DESCRIPTION
Hi,

If PHP is no longer available, the server sends the raw file with `Content-Type: application/x-httpd-php` and uses the default expiration value of 1 month for this content type.

This causes serious problems because when the PHP pool goes up, the browser continues to serve this raw file.

This is fixed by advising not to cache the `application/x-httpd-php` type.