### PR TITLE
Adding django server deployment template

### DIFF
--- a/vhosts/templates/django.example.com.conf
+++ b/vhosts/templates/django.example.com.conf
@@ -1,0 +1,47 @@
+# -----------------------------------------------------------------------
+# | Config file for example.com host to deploy django server via apache2 |
+# -----------------------------------------------------------------------
+# When you use daemon mode, the number of processes and threads is static. This is one of the immediate benefits of using daemon mode. 
+# Specifically, that process management is more predictable. One of the big problems with using embedded mode is that Apache can decide to create additional processes or kill off existing ones. 
+# For a web application with large startup costs this is not a good idea as you could suddenly see increased CPU usage due to more processes being started right at the time you don't need it such as when a throughput spike occurs. 
+# This can actually cause performance to degrade in the short term rather than improve.
+
+#Use Daemon Mode by Restricting WSGIRestrictEmbedded On
+WSGIRestrictEmbedded On
+
+<VirtualHost *:443>
+
+    # (1)
+    ServerName example.com
+    ServerAlias www.example.com
+
+    # Path for Django Project /home/DJANGO_PROJECT/
+    DocumentRoot $DJANGO_PROJECT 
+
+    WSGIDaemonProcess $DJANGO_PROJECT python-path=$DJANGO_PROJECT_DIR/$DJANGO_PROJECT:$DJANGO_PROJECT_DIR/$VIRTUAL_ENV/lib/python2.7/site-packages
+    WSGIProcessGroup $DJANGO_PROJECT
+    WSGIScriptAlias / $DJANGO_PROJECT_DIR/$DJANGO_PROJECT/$WSGI_RELATIVE_PATH
+
+    <Directory $DJANGO_PROJECT_DIR/$DJANGO_PROJECT>
+            <Files wsgi.py>
+            Require all granted
+            </Files>
+    </Directory>
+
+
+
+    Include h5bp/tls/ssl_engine.conf
+    Include h5bp/tls/certificate_files.conf
+    # Include h5bp/tls/policy_intermediate.conf 
+
+    # (1)
+    Include h5bp/rewrites/rewrite_nowww.conf
+
+    # Include the basic h5bp config set
+    Include h5bp/basic.conf
+
+    <Directory "/var/www/example.com/public">
+        Require all granted
+    </Directory>
+
+</VirtualHost>


### PR DESCRIPTION
- Added Django WSGI configuration on templates
- commented Include h5bp/tls/policy_intermediate.conf, because it didn't exists on /h5bp/tls/  on latest commit.

Added this because people couldn't find precise configuration files while deploying dev or production server, this repo is perfect and making standard, so I thought let's contribute more templates to it.

Please Review this configuration, so that if any issue I will work on that and make PR again.
Thanks !!