### PR TITLE
Remove charset from json and webmanifest

### DIFF
--- a/h5bp/media_types/character_encodings.conf
+++ b/h5bp/media_types/character_encodings.conf
@@ -23,7 +23,6 @@ AddDefaultCharset utf-8
                      .htc \
                      .ics \
                      .js \
-                     .json \
                      .manifest \
                      .map \
                      .markdown \
@@ -33,6 +32,5 @@ AddDefaultCharset utf-8
                      .vtt \
                      .vcard \
                      .vcf \
-                     .webmanifest \
                      .xloc
 </IfModule>

--- a/h5bp/web_performance/pre-compressed_content_brotli.conf
+++ b/h5bp/web_performance/pre-compressed_content_brotli.conf
@@ -43,8 +43,7 @@
             # Serve correct content charset
             AddCharset utf-8 .css.br \
                              .ics.br \
-                             .js.br \
-                             .json.br
+                             .js.br
         </IfModule>
 
         # Force proxies to cache brotlied and non-brotlied files separately

--- a/h5bp/web_performance/pre-compressed_content_gzip.conf
+++ b/h5bp/web_performance/pre-compressed_content_gzip.conf
@@ -43,8 +43,7 @@
             # Serve correct content charset
             AddCharset utf-8 .css.gz \
                              .ics.gz \
-                             .js.gz \
-                             .json.gz
+                             .js.gz
         </IfModule>
 
         # Force proxies to cache gzipped and non-gzipped files separately


### PR DESCRIPTION
The charset is not required and useless according to the IANA:

> Note:  No "charset" parameter is defined for this registration.
>   Adding one really has no effect on compliant recipients.

https://www.iana.org/assignments/media-types/application/json
https://www.iana.org/assignments/media-types/application/manifest+json