### PR TITLE
Add realpath to build.sh

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -3,7 +3,7 @@
 declare htaccess_config_default="bin/htaccess.conf";
 declare htaccess_output_default="./.htaccess"
 declare repo_root
-repo_root=$(dirname "$(dirname "$0")")
+repo_root=$(dirname "$(dirname "$(realpath "$0")")")
 
 # ----------------------------------------------------------------------
 # | Helper functions                                                   |


### PR DESCRIPTION
Correctly resolve build.sh's directory name even when script has been symlinked. Fixes #294 