### PR TITLE
Add a notice for directory index with pre-compressed content

### DIFF
--- a/h5bp/web_performance/pre-compressed_content_brotli.conf
+++ b/h5bp/web_performance/pre-compressed_content_brotli.conf
@@ -9,19 +9,9 @@
 #     own. Enabling this part will not auto-generate brotlied files.
 #
 # (!) In special case of serving pre-compressed content only, note that
-#     DirectoryIndex directive adjustments could be required to change default
-#     resources priorities.
-#     Example: for serving .br content only, with PHP and HTML fallback,
-#     you can set:
-#
-#              DirectoryIndex  index.br index.php index.html
-#
-#     In this example, DirectoryIndex directive would allow you to serve
-#     pre-compressed .br files by default as first resource and fallback
-#     to index.php and index.html, in that order, if pre-compressed content
-#     was not found.
-#
-# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+#     `DirectoryIndex` directive adjustments could be required to change
+#     default resources priorities.
+#     https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
 #
 # (1) Remove default Content-Language header added for .br files.
 #     https://httpd.apache.org/docs/current/mod/mod_mime.html#multipleext

--- a/h5bp/web_performance/pre-compressed_content_brotli.conf
+++ b/h5bp/web_performance/pre-compressed_content_brotli.conf
@@ -8,6 +8,21 @@
 # (!) To make this part relevant, you need to generate encoded files by your
 #     own. Enabling this part will not auto-generate brotlied files.
 #
+# (!) In special case of serving pre-compressed content only, note that
+#     DirectoryIndex directive adjustments could be required to change default
+#     resources priorities.
+#     Example: for serving .br content only, with PHP and HTML fallback,
+#     you can set:
+#
+#              DirectoryIndex  index.br index.php index.html
+#
+#     In this example, DirectoryIndex directive would allow you to serve
+#     pre-compressed .br files by default as first resource and fallback
+#     to index.php and index.html, in that order, if pre-compressed content
+#     was not found.
+#
+# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+#
 # (1) Remove default Content-Language header added for .br files.
 #     https://httpd.apache.org/docs/current/mod/mod_mime.html#multipleext
 #

--- a/h5bp/web_performance/pre-compressed_content_gzip.conf
+++ b/h5bp/web_performance/pre-compressed_content_gzip.conf
@@ -8,13 +8,28 @@
 # (!) To make this part relevant, you need to generate encoded files by your
 #     own. Enabling this part will not auto-generate gziped files.
 #
-# https://httpd.apache.org/docs/current/mod/mod_deflate.html#precompressed
+# (!) In special case of serving pre-compressed content only, note that
+#     DirectoryIndex directive adjustments could be required to change default
+#     resources priorities.
+#     Example: for serving .gz content only, with PHP and HTML fallback,
+#     you can set:
+#
+#              DirectoryIndex  index.gz index.php index.html
+#
+#     In this example, DirectoryIndex directive would allow you to serve
+#     pre-compressed .gz files by default as first resource and fallback
+#     to index.php and index.html, in that order, if pre-compressed content
+#     was not found.
+#
+# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
 #
 # (1) Removing default MIME Type for .gz files allowing to add custom
 #     sub-types.
 #     You may prefer using less generic extensions such as .html_gz in order to
 #     keep the default behavior regarding .gz files.
 #     https://httpd.apache.org/docs/current/mod/mod_mime.html#removetype
+#
+# https://httpd.apache.org/docs/current/mod/mod_deflate.html#precompressed
 
 <IfModule mod_rewrite.c>
 

--- a/h5bp/web_performance/pre-compressed_content_gzip.conf
+++ b/h5bp/web_performance/pre-compressed_content_gzip.conf
@@ -9,19 +9,9 @@
 #     own. Enabling this part will not auto-generate gziped files.
 #
 # (!) In special case of serving pre-compressed content only, note that
-#     DirectoryIndex directive adjustments could be required to change default
-#     resources priorities.
-#     Example: for serving .gz content only, with PHP and HTML fallback,
-#     you can set:
-#
-#              DirectoryIndex  index.gz index.php index.html
-#
-#     In this example, DirectoryIndex directive would allow you to serve
-#     pre-compressed .gz files by default as first resource and fallback
-#     to index.php and index.html, in that order, if pre-compressed content
-#     was not found.
-#
-# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+#     `DirectoryIndex` directive adjustments could be required to change
+#     default resources priorities.
+#     https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
 #
 # (1) Removing default MIME Type for .gz files allowing to add custom
 #     sub-types.


### PR DESCRIPTION
Added comment about serving Gzip and brotli pre-compressed resources only and how to do that, with one `DirectoryIndex` directive example for that case.

Also, moved Apache Gzip article link to the bottom to match writing style of `pre-compressed_content_brotli.conf` file.