### PR TITLE
Document pre-compressed content usage in Virtual Hosts

### DIFF
--- a/h5bp/web_performance/pre-compressed_content_brotli.conf
+++ b/h5bp/web_performance/pre-compressed_content_brotli.conf
@@ -13,14 +13,11 @@
 #     default resources priorities.
 #     https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
 #
-# (1) REQUEST_FILENAME will only contain a filepath if the translation
-#     from URI to filepath has already been completed.
-#     If the translation is still pending the variable is equal to REQUEST_URI
-#     Translation is usually still pending when using it in VirtualHost context.
-#     We can use a lookahead by prepending LA-U:
-#     This way we can check the final filepath even in contexts where it
-#     would not be possible otherwise.
-#     https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#rewritecond 
+# (1) In a virtual host context, `REQUEST_FILENAME` may be equal to
+#     `REQUEST_URI` while URL translation to file path is still pending.
+#     In that case, enabling the look-ahead flag on `RewriteCond` (`LA-U`)
+#     will extract URI last segment to work around a file path resolution.
+#     https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritecond 
 #
 # (2) Remove default Content-Language header added for .br files.
 #     https://httpd.apache.org/docs/current/mod/mod_mime.html#multipleext
@@ -35,7 +32,8 @@
 
     RewriteCond %{HTTP:Accept-Encoding} br
     # (1)
-    RewriteCond %{LA-U:REQUEST_FILENAME}\.br -f
+    RewriteCond %{REQUEST_FILENAME}\.br -f
+    # RewriteCond %{LA-U:REQUEST_FILENAME}\.br -f
     RewriteRule \.(css|ics|js|json|html|svg)$ %{REQUEST_URI}.br [L]
 
     # Prevent mod_deflate double gzip

--- a/h5bp/web_performance/pre-compressed_content_brotli.conf
+++ b/h5bp/web_performance/pre-compressed_content_brotli.conf
@@ -13,7 +13,16 @@
 #     default resources priorities.
 #     https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
 #
-# (1) Remove default Content-Language header added for .br files.
+# (1) REQUEST_FILENAME will only contain a filepath if the translation
+#     from URI to filepath has already been completed.
+#     If the translation is still pending the variable is equal to REQUEST_URI
+#     Translation is usually still pending when using it in VirtualHost context.
+#     We can use a lookahead by prepending LA-U:
+#     This way we can check the final filepath even in contexts where it
+#     would not be possible otherwise.
+#     https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#rewritecond 
+#
+# (2) Remove default Content-Language header added for .br files.
 #     https://httpd.apache.org/docs/current/mod/mod_mime.html#multipleext
 #
 # Note that some clients (e.g. browsers) require a secure connection to request
@@ -25,7 +34,8 @@
 <IfModule mod_rewrite.c>
 
     RewriteCond %{HTTP:Accept-Encoding} br
-    RewriteCond %{REQUEST_FILENAME}\.br -f
+    # (1)
+    RewriteCond %{LA-U:REQUEST_FILENAME}\.br -f
     RewriteRule \.(css|ics|js|json|html|svg)$ %{REQUEST_URI}.br [L]
 
     # Prevent mod_deflate double gzip
@@ -34,7 +44,7 @@
     <FilesMatch "\.br$">
 
         <IfModule mod_mime.c>
-            # (1)
+            # (2)
             RemoveLanguage .br
 
             # Serve correct content types

--- a/h5bp/web_performance/pre-compressed_content_gzip.conf
+++ b/h5bp/web_performance/pre-compressed_content_gzip.conf
@@ -13,7 +13,16 @@
 #     default resources priorities.
 #     https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
 #
-# (1) Removing default MIME Type for .gz files allowing to add custom
+# (1) REQUEST_FILENAME will only contain a filepath if the translation
+#     from URI to filepath has already been completed.
+#     If the translation is still pending the variable is equal to REQUEST_URI
+#     Translation is usually still pending when using it in VirtualHost context.
+#     We can use a lookahead by prepending LA-U:
+#     This way we can check the final filepath even in contexts where it
+#     would not be possible otherwise.
+#     https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#rewritecond 
+#
+# (2) Removing default MIME Type for .gz files allowing to add custom
 #     sub-types.
 #     You may prefer using less generic extensions such as .html_gz in order to
 #     keep the default behavior regarding .gz files.
@@ -24,7 +33,8 @@
 <IfModule mod_rewrite.c>
 
     RewriteCond %{HTTP:Accept-Encoding} gzip
-    RewriteCond %{REQUEST_FILENAME}\.gz -f
+    # (1)
+    RewriteCond %{LA-U:REQUEST_FILENAME}\.gz -f
     RewriteRule \.(css|ics|js|json|html|svg)$ %{REQUEST_URI}.gz [L]
 
     # Prevent mod_deflate double gzip
@@ -33,7 +43,7 @@
     <FilesMatch "\.gz$">
 
         <IfModule mod_mime.c>
-            # (1)
+            # (2)
             RemoveType gz
 
             # Serve correct content types

--- a/h5bp/web_performance/pre-compressed_content_gzip.conf
+++ b/h5bp/web_performance/pre-compressed_content_gzip.conf
@@ -13,14 +13,11 @@
 #     default resources priorities.
 #     https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
 #
-# (1) REQUEST_FILENAME will only contain a filepath if the translation
-#     from URI to filepath has already been completed.
-#     If the translation is still pending the variable is equal to REQUEST_URI
-#     Translation is usually still pending when using it in VirtualHost context.
-#     We can use a lookahead by prepending LA-U:
-#     This way we can check the final filepath even in contexts where it
-#     would not be possible otherwise.
-#     https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#rewritecond 
+# (1) In a virtual host context, `REQUEST_FILENAME` may be equal to
+#     `REQUEST_URI` while URL translation to file path is still pending.
+#     In that case, enabling the look-ahead flag on `RewriteCond` (`LA-U`)
+#     will extract URI last segment to work around a file path resolution.
+#     https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritecond 
 #
 # (2) Removing default MIME Type for .gz files allowing to add custom
 #     sub-types.
@@ -34,7 +31,8 @@
 
     RewriteCond %{HTTP:Accept-Encoding} gzip
     # (1)
-    RewriteCond %{LA-U:REQUEST_FILENAME}\.gz -f
+    RewriteCond %{REQUEST_FILENAME}\.gz -f
+    # RewriteCond %{LA-U:REQUEST_FILENAME}\.gz -f
     RewriteRule \.(css|ics|js|json|html|svg)$ %{REQUEST_URI}.gz [L]
 
     # Prevent mod_deflate double gzip


### PR DESCRIPTION
I used the rules for delivering precompressed brotli and gzip content for my server, but neither using `RewriteOptions Inherit` nor pasting the rules directly into the Virtual Host config enabled my Virtual Hosts to actually serve the precompressed content.

I activated tracing logs for mod_rewrite and saw that `REQUEST_FILENAME` contained the path of the request instead of a final filesystem path. Reading up on mod_rewrite documentation I found out that this can indeed happen depending on the current state of the URI to file translation of the request. Virtual Hosts are one case where the variable usually still contains the request URI instead of a filesystem path. [The documentation mentions a lookahead, though](https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#rewritecond:~:text=If%20used%20in,value%20of%20REQUEST_FILENAME.). This PR implements this lookahead so the rule also works in contexts such as Virtual Hosts.