### PR TITLE
Add explanatory text in case `ExpiresDefault` is not applied by default

### DIFF
--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -48,6 +48,13 @@
     ExpiresByType application/xml                       "access"
     ExpiresByType text/xml                              "access"
 
+# Keep in mind that the webserver config may have already a preset some file types.
+# If so the general rule with "ExpiresDefault" won't be applied for these types.
+# This applies especially to image types. If you are not sure or are not able to check the config
+# you can test your website with tools such as "Google Lighthouse" or https://pagespeed.web.dev/ 
+# and look for complaints like "Serve static assets with an efficient cache policy".
+# In order to override any preset(s), uncomment the appropriate lines below.
+
     # Generic: WebAssembly
     # ExpiresByType application/wasm                    "access plus 1 year" # default
 

--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -7,6 +7,13 @@
 # (!) If you don't control versioning with filename-based cache busting, you
 #     should consider lowering the cache times to something like one week.
 #
+# (!) When using `.htaccess` file, the webserver config may have already
+#     a preset some file types.
+#     In that case, the general rule with `ExpiresDefault` might not be applied.
+#     In order to override any presets, uncomment the appropriate "Generic"
+#     lines below.
+#     Online checker or validators can help investigating the served cache policy.
+#
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires
 # https://httpd.apache.org/docs/current/mod/mod_expires.html
@@ -47,13 +54,6 @@
     ExpiresByType application/geo+json                  "access"
     ExpiresByType application/xml                       "access"
     ExpiresByType text/xml                              "access"
-
-# Keep in mind that the webserver config may have already a preset some file types.
-# If so the general rule with "ExpiresDefault" won't be applied for these types.
-# This applies especially to image types. If you are not sure or are not able to check the config
-# you can test your website with tools such as "Google Lighthouse" or https://pagespeed.web.dev/ 
-# and look for complaints like "Serve static assets with an efficient cache policy".
-# In order to override any preset(s), uncomment the appropriate lines below.
 
     # Generic: WebAssembly
     # ExpiresByType application/wasm                    "access plus 1 year" # default


### PR DESCRIPTION
Added explanatory text in case "ExpiresDefault" is not applied by default.