### PR TITLE
Document rewrite inheritance in virtual host templates

### DIFF
--- a/vhosts/templates/example.com.conf
+++ b/vhosts/templates/example.com.conf
@@ -27,6 +27,10 @@
     # Include the basic h5bp config set
     Include h5bp/basic.conf
 
+    # Uncomment to inherit rewrite rules from the main server configuration.
+    # Inherited rules are applied after rules defined in this virtual host.
+    # RewriteOptions Inherit
+
     <Directory "/var/www/example.com/public">
         Require all granted
     </Directory>

--- a/vhosts/templates/no-ssl.example.com.conf
+++ b/vhosts/templates/no-ssl.example.com.conf
@@ -23,6 +23,10 @@
     # Include the basic h5bp config set
     Include h5bp/basic.conf
 
+    # Uncomment to inherit rewrite rules from the main server configuration.
+    # Inherited rules are applied after rules defined in this virtual host.
+    # RewriteOptions Inherit
+
     <Directory "/var/www/example.com/public">
         Require all granted
     </Directory>


### PR DESCRIPTION
## Summary

- add a commented-out `RewriteOptions Inherit` option to both virtual host templates
- explain that inherited main-server rules run after rules defined in the virtual host
- keep rewrite inheritance disabled by default

Closes #337.

## Verification

- `./test/build/test_userbuild.sh`
- Apache 2.4.66 `httpd -t` with `RewriteOptions Inherit` in virtual-host context
- comment-stripped effective configuration matches `main` for both templates
- `git diff --check`
